### PR TITLE
fix cli bug

### DIFF
--- a/src/commands/setup/gen-keystore.ts
+++ b/src/commands/setup/gen-keystore.ts
@@ -52,7 +52,14 @@ export default class SetupGenKeystore extends Command {
   }
 
   private async generateSequencerKeystore(index: number): Promise<SequencerData> {
-    const password = await input({ message: `Enter a password for sequencer-${index} keystore:` })
+    let password = ''
+    while (!password) {
+      password = await input({ message: `Enter a password for sequencer-${index} keystore:` })
+      if (!password) {
+        console.log('Password cannot be empty. Please try again.')
+      }
+    }
+    
     const wallet = Wallet.createRandom()
     const encryptedJson = await wallet.encrypt(password)
     return {

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -138,9 +138,9 @@ export default class SetupPrepCharts extends Command {
           if (configMapData && typeof configMapData === 'object' && 'data' in configMapData) {
             const envData = (configMapData as any).data
             for (const [key, value] of Object.entries(envData)) {
-              if (value === '' || value === '[""]' || value === '[]' ||
-                (Array.isArray(value) && (value.length === 0 || (value.length === 1 && value[0] === ''))) ||
-                value === null || value === undefined) {
+              // if (value === '' || value === '[""]' || value === '[]' ||
+              //   (Array.isArray(value) && (value.length === 0 || (value.length === 1 && value[0] === ''))) ||
+              //   value === null || value === undefined) {
                 const configMapping = this.configMapping[key]
                 if (configMapping) {
                   let configKey: string
@@ -157,14 +157,20 @@ export default class SetupPrepCharts extends Command {
                     } else {
                       newValue = String(configValue)
                     }
-                    changes.push({ key, oldValue: JSON.stringify(value), newValue: newValue })
-                    envData[key] = newValue
-                    updated = true
+
+                    if(chartName === "l1-devnet" && key === "CHAIN_ID"){
+                      continue;
+                    }
+                    if (newValue != value) {
+                      changes.push({ key, oldValue: JSON.stringify(value), newValue: newValue })
+                      envData[key] = newValue
+                      updated = true
+                    }
                   } else {
                     this.log(chalk.yellow(`${chartName}: No value found for ${configKey}`))
                   }
                 }
-              }
+              //}
             }
           }
         }

--- a/src/commands/setup/push-secrets.ts
+++ b/src/commands/setup/push-secrets.ts
@@ -369,7 +369,7 @@ export default class SetupPushSecrets extends Command {
     }
   }
 
-  private async updateProductionYaml(provider: string): Promise<void> {
+  private async updateProductionYaml(provider: string, prefixName?: string): Promise<void> {
     const valuesDir = path.join(process.cwd(), this.flags['values-dir']);
     if (!fs.existsSync(valuesDir)) {
       this.error(chalk.red(`Values directory not found at ${valuesDir}`));
@@ -432,17 +432,19 @@ export default class SetupPushSecrets extends Command {
           }
 
           // Update remoteRef for l2-sequencer secrets
-          if (secretName.match(/^l2-sequencer-\d+-secret$/)) {
+          if (secretName.match(/^l2-sequencer-secret-\d+-env$/)) {
             for (const data of secret.data) {
               if (data.remoteRef && data.remoteRef.key) {
-                data.remoteRef.key = 'l2-sequencer-secret';
+                // Use the prefixName if available
+                const prefix = prefixName || (data.remoteRef.key.startsWith('scroll/') ? 'scroll' : '');
+                data.remoteRef.key = `${prefix}/l2-sequencer-secret-env`;
                 updated = true;
               }
             }
           }
         }
       }
-
+      
       if (updated) {
         const newContent = yaml.dump(yamlContent, { lineWidth: -1, noRefs: true, quotingType: '"', forceQuotes: true });
         fs.writeFileSync(yamlPath, newContent);
@@ -470,11 +472,13 @@ export default class SetupPushSecrets extends Command {
 
     let service: SecretService
     let provider: string
+    let prefixName: string | undefined
 
     if (secretService === 'aws') {
       const awsCredentials = await this.getAWSCredentials()
       service = new AWSSecretService(awsCredentials.secretRegion, awsCredentials.prefixName, flags.debug)
       provider = 'aws'
+      prefixName = awsCredentials.prefixName
     } else if (secretService === 'vault') {
       service = new HashicorpVaultDevService(flags.debug)
       provider = 'vault'
@@ -491,7 +495,7 @@ export default class SetupPushSecrets extends Command {
       })
 
       if (shouldUpdateYaml) {
-        await this.updateProductionYaml(provider)
+        await this.updateProductionYaml(provider, prefixName)
         this.log(chalk.green('Production YAML files updated successfully'))
       } else {
         this.log(chalk.yellow('Skipped updating production YAML files'))


### PR DESCRIPTION
1. fix bug that if reexecute 'setup gen-keystore', the l2-sequencer-p…
2. fix bug that 'setup push-secrets' did not update prefix of remoteRef.key in file 'l2-sequencer-production-*.yaml'
3. remind users that passowrd of keystore can not be empty.