### PR TITLE
Shu fix bugs (#7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scroll-tech/scroll-sdk-cli",
-  "description": "A tool for managing and testing Scroll SDK deployments",
-  "version": "0.1.2",
+  "description": "A tool for managing and testing Scroll SDK(Dogeos) deployments",
+  "version": "0.1.3",
   "author": "Daniel Helm",
   "bin": {
     "scrollsdk": "bin/run.js"
@@ -48,7 +48,7 @@
     "eslint-config-prettier": "^9",
     "mocha": "^10",
     "oclif": "^4",
-    "shx": "^0.3.3",
+    "shx": "^0.4.0",
     "sinon": "^18.0.0",
     "ts-node": "^10",
     "typescript": "^5"

--- a/src/commands/setup/configs.ts
+++ b/src/commands/setup/configs.ts
@@ -14,7 +14,7 @@ export default class SetupConfigs extends Command {
 
   static override examples = [
     '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> --image-tag gen-configs-9b29d9b6dcea6828118c0ee63d208095265f3a03',
+    '<%= config.bin %> <%= command.id %> --image-tag gen-configs-f961bf3e75c7c3fec63250062e751b0aaf47fefd',
     '<%= config.bin %> <%= command.id %> --configs-dir custom-configs',
   ]
 
@@ -465,7 +465,7 @@ export default class SetupConfigs extends Command {
   }
 
   private async getDockerImageTag(providedTag: string | undefined): Promise<string> {
-    const defaultTag = 'gen-configs-9b29d9b6dcea6828118c0ee63d208095265f3a03'
+    const defaultTag = 'gen-configs-f961bf3e75c7c3fec63250062e751b0aaf47fefd'
 
     if (!providedTag) {
       return defaultTag

--- a/src/commands/setup/db-init.ts
+++ b/src/commands/setup/db-init.ts
@@ -377,7 +377,7 @@ export default class SetupDbInit extends Command {
     this.log(chalk.blue('First, provide connection information for the database instance. This will only be used for creating users and databases. This information will not be persisted in your configuration repo.'));
     const publicHost = await input({ message: 'Enter public PostgreSQL host:', default: 'localhost' })
     const publicPort = await input({ message: 'Enter public PostgreSQL port:', default: '5432' })
-    const pgUser = await input({ message: 'Enter PostgreSQL admin username:', default: 'admin' })
+    const pgUser = await input({ message: 'Enter PostgreSQL admin username:', default: 'scrolladmin' })
     const pgPassword = await password({ message: 'Enter PostgreSQL admin password:' })
     const pgDatabase = await input({ message: 'Enter PostgreSQL database name:', default: 'postgres' })
 

--- a/src/commands/setup/domains.ts
+++ b/src/commands/setup/domains.ts
@@ -457,6 +457,23 @@ export default class SetupDomains extends Command {
       delete existingConfig.ingress.L1_EXPLORER_HOST
     }
 
+    /*
+    [contracts.verification]
+    VERIFIER_TYPE_L1 = "blockscout"
+    VERIFIER_TYPE_L2 = "blockscout"
+    EXPLORER_URI_L1 = "http://l1-explorer.scrollsdk"
+    EXPLORER_URI_L2 = "http://blockscout.scrollsdk"
+    RPC_URI_L1 = "http://l1-devnet.scrollsdk"
+    RPC_URI_L2 = "http://l2-rpc.scrollsdk"
+    EXPLORER_API_KEY_L1 = ""
+    EXPLORER_API_KEY_L2 = ""
+    */
+    existingConfig.contracts.verification.EXPLORER_URI_L1 = domainConfig.EXTERNAL_EXPLORER_URI_L1;
+    existingConfig.contracts.verification.EXPLORER_URI_L2 = domainConfig.EXTERNAL_EXPLORER_URI_L2;
+    existingConfig.contracts.verification.RPC_URI_L1 = domainConfig.EXTERNAL_RPC_URI_L1;
+    existingConfig.contracts.verification.RPC_URI_L2 = domainConfig.EXTERNAL_RPC_URI_L2;
+    
+
     // Convert the updated config back to TOML string
     const updatedContent = toml.stringify(existingConfig)
 

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -113,6 +113,8 @@ export default class SetupPrepCharts extends Command {
   }
 
   private async processProductionYaml(valuesDir: string): Promise<{ updated: number; skipped: number }> {
+
+
     const productionFiles = fs.readdirSync(valuesDir)
       .filter(file => file.endsWith('-production.yaml') || file.match(/-production-\d+\.yaml$/))
 
@@ -141,36 +143,35 @@ export default class SetupPrepCharts extends Command {
               // if (value === '' || value === '[""]' || value === '[]' ||
               //   (Array.isArray(value) && (value.length === 0 || (value.length === 1 && value[0] === ''))) ||
               //   value === null || value === undefined) {
-                const configMapping = this.configMapping[key]
-                if (configMapping) {
-                  let configKey: string
-                  if (typeof configMapping === 'function') {
-                    configKey = configMapping(chartName, productionNumber)
-                  } else {
-                    configKey = configMapping
-                  }
-                  const configValue = this.getConfigValue(configKey)
-                  if (configValue !== undefined && configValue !== null) {
-                    let newValue: string | string[]
-                    if (Array.isArray(configValue)) {
-                      newValue = JSON.stringify(configValue)
-                    } else {
-                      newValue = String(configValue)
-                    }
-
-                    if(chartName === "l1-devnet" && key === "CHAIN_ID"){
-                      continue;
-                    }
-                    if (newValue != value) {
-                      changes.push({ key, oldValue: JSON.stringify(value), newValue: newValue })
-                      envData[key] = newValue
-                      updated = true
-                    }
-                  } else {
-                    this.log(chalk.yellow(`${chartName}: No value found for ${configKey}`))
-                  }
+              const configMapping = this.configMapping[key]
+              if (configMapping) {
+                let configKey: string
+                if (typeof configMapping === 'function') {
+                  configKey = configMapping(chartName, productionNumber)
+                } else {
+                  configKey = configMapping
                 }
-              //}
+                if (chartName === "l1-devnet" && key === "CHAIN_ID") {
+                  configKey = "general.CHAIN_ID_L1";
+                }
+
+                const configValue = this.getConfigValue(configKey)
+                if (configValue !== undefined && configValue !== null) {
+                  let newValue: string | string[]
+                  if (Array.isArray(configValue)) {
+                    newValue = JSON.stringify(configValue)
+                  } else {
+                    newValue = String(configValue)
+                  }
+                  if (newValue != value) {
+                    changes.push({ key, oldValue: JSON.stringify(value), newValue: newValue })
+                    envData[key] = newValue
+                    updated = true
+                  }
+                } else {
+                  this.log(chalk.yellow(`${chartName}: No value found for ${configKey}`))
+                }
+              }
             }
           }
         }
@@ -241,6 +242,126 @@ export default class SetupPrepCharts extends Command {
               }
             }
           }
+        }
+      }
+      /*
+      blockscout-stack.blockscout.ingress.annotations.nginx.ingress.kubernetes.io/cors-allow-origin:https://blockscout.scrollsdk
+      blockscout-stack.blockscout.ingress.hostname:blockscout.scrollsdk
+      blockscout-stack.frontend.env.NEXT_PUBLIC_API_HOST:blockscout.scrollsdk
+      blockscout-stack.frontend.ingress.annotations.nginx.ingress.kubernetes.io/cors-allow-origin: "https://blockscout.scrollsdk"
+      blockscout-stack.frontend.ingress.hostname: "blockscout.scrollsdk"
+      */
+      if (productionYaml["blockscout-stack"]) {
+        let ingressUpdated = false;
+        const blockscout = productionYaml["blockscout-stack"].blockscout;
+        const frontend = productionYaml["blockscout-stack"].frontend;
+        let blockscout_host = this.getConfigValue("ingress.BLOCKSCOUT_HOST");
+        let blockscout_url = this.getConfigValue("frontend.EXTERNAL_EXPLORER_URI_L2");
+
+        if (blockscout?.ingress?.annotations?.["nginx.ingress.kubernetes.io/cors-allow-origin"]) {
+          changes.push({ key: `ingress.blockscout.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"]`, oldValue: blockscout.ingress.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"], newValue: blockscout_url });
+          blockscout.ingress.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"] = blockscout_url;
+          ingressUpdated = true;
+        }
+
+        if (blockscout?.ingress?.hostname) {
+          changes.push({ key: `ingress.blockscout.hostname`, oldValue: blockscout.ingress.hostname, newValue: blockscout_host });
+          blockscout.ingress.hostname = blockscout_host;
+          ingressUpdated = true;
+        }
+        if (frontend?.env?.NEXT_PUBLIC_API_HOST) {
+          changes.push({ key: `frontend.env.NEXT_PUBLIC_API_HOST`, oldValue: frontend.env.NEXT_PUBLIC_API_HOST, newValue: blockscout_host });
+          frontend.env.NEXT_PUBLIC_API_HOST = blockscout_host;
+          ingressUpdated = true;
+        }
+        if (frontend?.ingress?.annotations?.["nginx.ingress.kubernetes.io/cors-allow-origin"]) {
+          changes.push({ key: `frontend.ingress.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"]`, oldValue: frontend.ingress.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"], newValue: blockscout_url });
+          frontend.ingress.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"] = blockscout_url;
+          ingressUpdated = true;
+        }
+        if (frontend?.ingress?.hostname) {
+          changes.push({ key: `frontend.ingress.hostname`, oldValue: frontend.ingress.hostname, newValue: blockscout_host });
+          frontend.ingress.hostname = blockscout_host;
+          ingressUpdated = true;
+        }
+        /*
+        INDEXER_SCROLL_L1_CHAIN_CONTRACT: ""
+        INDEXER_SCROLL_L1_BATCH_START_BLOCK: ""
+        INDEXER_SCROLL_L1_MESSENGER_CONTRACT: ""
+        INDEXER_SCROLL_L1_MESSENGER_START_BLOCK: ""
+        INDEXER_SCROLL_L2_MESSENGER_CONTRACT: ""
+        INDEXER_SCROLL_L2_GAS_ORACLE_CONTRACT: ""
+        INDEXER_SCROLL_L1_RPC: ""
+              INDEXER_SCROLL_L2_MESSENGER_START_BLOCK: 0
+      INDEXER_SCROLL_L1_ETH_GET_LOGS_RANGE_SIZE: 500
+      INDEXER_SCROLL_L2_ETH_GET_LOGS_RANGE_SIZE: 500
+        */
+        interface BlockscoutEnvMapping {
+          key: string;
+          configKey: string;
+          defaultValue?: string;
+        }
+
+        const BLOCKSCOUT_ENV_MAPPINGS: BlockscoutEnvMapping[] = [
+          {
+            key: 'INDEXER_SCROLL_L1_BATCH_START_BLOCK',
+            configKey: '',
+            defaultValue: '0'
+          },
+          {
+            key: 'INDEXER_SCROLL_L1_MESSENGER_START_BLOCK',
+            configKey: '',
+            defaultValue: '0'
+          },
+          {
+            key: 'INDEXER_SCROLL_L1_CHAIN_CONTRACT',
+            configKey: 'contractsFile.L1_SCROLL_CHAIN_PROXY_ADDR'
+          },
+          {
+            key: 'INDEXER_SCROLL_L1_MESSENGER_CONTRACT',
+            configKey: 'L1_SCROLL_MESSENGER_PROXY_ADDR'
+          },
+          {
+            key: 'INDEXER_SCROLL_L2_MESSENGER_CONTRACT',
+            configKey: 'L2_SCROLL_MESSENGER_PROXY_ADDR'
+          },
+          {
+            key: 'INDEXER_SCROLL_L2_GAS_ORACLE_CONTRACT',
+            configKey: 'L1_GAS_PRICE_ORACLE_ADDR'
+          },
+          {
+            key: 'INDEXER_SCROLL_L1_RPC',
+            configKey: 'general.L1_RPC_ENDPOINT'
+          }
+
+
+        ];
+        const benv = productionYaml["blockscout-stack"].blockscout.env;
+
+        BLOCKSCOUT_ENV_MAPPINGS.forEach(mapping => {
+          const { key, configKey, defaultValue } = mapping;
+
+          let newValue = this.getConfigValue(configKey);
+          if (!newValue) {
+            newValue = configKey ? this.contractsConfig[configKey] : defaultValue;
+          }
+
+          if (newValue !== undefined) {
+            changes.push({
+              key: `blockscout.env.${key}`,
+              oldValue: benv[key],
+              newValue: newValue
+            });
+            benv[key] = newValue;
+          } else {
+            this.log(chalk.yellow(`No value found for ${key}`));
+          }
+        });
+
+        updated = true;
+
+        if (ingressUpdated) {
+          updated = true;
         }
       }
 

--- a/src/commands/setup/push-secrets.ts
+++ b/src/commands/setup/push-secrets.ts
@@ -33,6 +33,10 @@ class AWSSecretService implements SecretService {
     const fullSecretName = `${this.prefixName}/${secretName}`
     const jsonContent = JSON.stringify(content)
     const escapedJsonContent = jsonContent.replace(/'/g, "'\\''")
+    if (!jsonContent) {
+      console.log(chalk.red(`Skipping secret: ${secretName} because it is empty`))
+      return
+    }
 
     if (await this.secretExists(secretName)) {
       const shouldOverride = await confirm({
@@ -112,15 +116,31 @@ class AWSSecretService implements SecretService {
     let l2SequencerSecrets: Record<string, string> = {}
 
     for (const file of envFiles) {
-      const secretName = path.basename(file, '.env')
-      if (secretName.startsWith('l2-sequencer-')) {
+      const baseName = path.basename(file, '.env')
+
+      // Special handling for l2-sequencer-N-secret.env files
+      if (baseName.match(/^l2-sequencer-\d+-secret$/)) {
+        const sequencerIndex = baseName.match(/l2-sequencer-(\d+)-secret/)?.[1] || '0'
+        const secretName = `l2-sequencer-secret-${sequencerIndex}-env`
+
         console.log(chalk.cyan(`Processing L2 Sequencer secret: ${secretName}`))
         const data = await this.convertEnvToDict(path.join(secretsDir, file))
-        l2SequencerSecrets = { ...l2SequencerSecrets, ...data }
+        await this.createOrUpdateSecret(data, secretName)
+
+        // Also add to combined secret with index suffix for backward compatibility
+        for (const [key, value] of Object.entries(data)) {
+          // If key already has index suffix, use it as is, otherwise add index suffix
+          if (key.endsWith(`_${sequencerIndex}`)) {
+            l2SequencerSecrets[key] = value
+          } else {
+            l2SequencerSecrets[`${key}_${sequencerIndex}`] = value
+          }
+        }
       } else {
-        console.log(chalk.cyan(`Processing ENV secret: ${secretName}-env`))
+        const secretName = `${baseName}-env`
+        console.log(chalk.cyan(`Processing ENV secret: ${secretName}`))
         const data = await this.convertEnvToDict(path.join(secretsDir, file))
-        await this.createOrUpdateSecret(data, `${secretName}-env`)
+        await this.createOrUpdateSecret(data, secretName)
       }
     }
 
@@ -134,9 +154,11 @@ class AWSSecretService implements SecretService {
 
 class HashicorpVaultDevService implements SecretService {
   private debug: boolean
+  private pathPrefix: string
 
-  constructor(debug: boolean) {
+  constructor(debug: boolean, pathPrefix: string = 'scroll') {
     this.debug = debug
+    this.pathPrefix = pathPrefix
   }
 
   private async runCommand(command: string): Promise<string> {
@@ -195,7 +217,11 @@ class HashicorpVaultDevService implements SecretService {
       .map(([key, value]) => `${key}='${value.replace(/'/g, "'\\''")}'`)
       .join(' ')
 
-    const command = `vault kv put scroll/${secretName} ${kvPairs}`
+    if (!kvPairs) {
+      console.log(chalk.red(`Skipping secret: ${secretName} because it is empty`))
+      return
+    }
+    const command = `vault kv put ${this.pathPrefix}/${secretName} ${kvPairs}`
 
     if (this.debug) {
       console.log(chalk.yellow('--- Debug Output ---'))
@@ -206,9 +232,9 @@ class HashicorpVaultDevService implements SecretService {
 
     try {
       await this.runCommand(command)
-      console.log(chalk.green(`Successfully pushed secret: scroll/${secretName}`))
+      console.log(chalk.green(`Successfully pushed secret: ${this.pathPrefix}/${secretName}`))
     } catch (error) {
-      console.error(chalk.red(`Failed to push secret: scroll/${secretName}`))
+      console.error(chalk.red(`Failed to push secret: ${this.pathPrefix}/${secretName}`))
       console.error(chalk.red(`Error: ${error}`))
     }
   }
@@ -217,7 +243,7 @@ class HashicorpVaultDevService implements SecretService {
     try {
       const jsonContent = JSON.parse(content);
       const escapedJson = JSON.stringify(jsonContent).replace(/'/g, "'\\''");
-      const command = `vault kv put scroll/${secretName} migrate-db.json='${escapedJson}'`;
+      const command = `vault kv put ${this.pathPrefix}/${secretName} migrate-db.json='${escapedJson}'`;
 
       if (this.debug) {
         console.log(chalk.yellow('--- Debug Output ---'));
@@ -226,10 +252,15 @@ class HashicorpVaultDevService implements SecretService {
         console.log(chalk.yellow('-------------------'));
       }
 
+      if (!jsonContent) {
+        console.log(chalk.red(`Skipping secret: ${secretName} because it is empty`))
+        return
+      }
+
       await this.runCommand(command);
-      console.log(chalk.green(`Successfully pushed JSON secret: scroll/${secretName}`));
+      console.log(chalk.green(`Successfully pushed JSON secret: ${this.pathPrefix}/${secretName}`));
     } catch (error) {
-      console.error(chalk.red(`Failed to push JSON secret: scroll/${secretName}`));
+      console.error(chalk.red(`Failed to push JSON secret: ${this.pathPrefix}/${secretName}`));
       console.error(chalk.red(`Error: ${error}`));
     }
   }
@@ -245,26 +276,26 @@ class HashicorpVaultDevService implements SecretService {
     }
 
     // Check if the KV secrets engine is already enabled
-    const isEnabled = await this.isSecretEngineEnabled('scroll')
+    const isEnabled = await this.isSecretEngineEnabled(this.pathPrefix)
     if (!isEnabled) {
       // Enable the KV secrets engine only if it's not already enabled
       try {
-        await this.runCommand("vault secrets enable -path=scroll kv-v2")
-        console.log(chalk.green("KV secrets engine enabled at path 'scroll'"))
+        await this.runCommand(`vault secrets enable -path=${this.pathPrefix} kv-v2`)
+        console.log(chalk.green(`KV secrets engine enabled at path '${this.pathPrefix}'`))
       } catch (error: unknown) {
         if (error instanceof Error) {
           // If the error is about the path already in use, we can ignore it
-          if (!error.message.includes("path is already in use at scroll/")) {
+          if (!error.message.includes(`path is already in use at ${this.pathPrefix}/`)) {
             throw error
           }
-          console.log(chalk.yellow("KV secrets engine already enabled at path 'scroll'"))
+          console.log(chalk.yellow(`KV secrets engine already enabled at path '${this.pathPrefix}'`))
         } else {
           // If it's not an Error instance, rethrow it
           throw error
         }
       }
     } else {
-      console.log(chalk.yellow("KV secrets engine already enabled at path 'scroll'"))
+      console.log(chalk.yellow(`KV secrets engine already enabled at path '${this.pathPrefix}'`))
     }
 
     const secretsDir = path.join(process.cwd(), 'secrets')
@@ -273,7 +304,7 @@ class HashicorpVaultDevService implements SecretService {
     const jsonFiles = fs.readdirSync(secretsDir).filter(file => file.endsWith('.json'))
     for (const file of jsonFiles) {
       const secretName = path.basename(file, '.json')
-      console.log(chalk.cyan(`Processing JSON secret: scroll/${secretName}`))
+      console.log(chalk.cyan(`Processing JSON secret: ${this.pathPrefix}/${secretName}`))
       const content = await fs.promises.readFile(path.join(secretsDir, file), 'utf-8')
       await this.pushJsonToVault(secretName, content)
     }
@@ -283,21 +314,37 @@ class HashicorpVaultDevService implements SecretService {
     let l2SequencerSecrets: Record<string, string> = {}
 
     for (const file of envFiles) {
-      const secretName = path.basename(file, '.env') + '-env'
-      if (secretName.startsWith('l2-sequencer-')) {
-        console.log(chalk.cyan(`Processing L2 Sequencer secret: ${secretName}`))
+      const baseName = path.basename(file, '.env')
+
+      // Special handling for l2-sequencer-N-secret.env files
+      if (baseName.match(/^l2-sequencer-\d+-secret$/)) {
+        const sequencerIndex = baseName.match(/l2-sequencer-(\d+)-secret/)?.[1] || '0'
+        const secretName = `l2-sequencer-secret-${sequencerIndex}-env`
+
+        console.log(chalk.cyan(`Processing L2 Sequencer secret: ${this.pathPrefix}/${secretName}`))
         const data = await this.convertEnvToDict(path.join(secretsDir, file))
-        l2SequencerSecrets = { ...l2SequencerSecrets, ...data }
+        await this.pushToVault(secretName, data)
+
+        // Also add to combined secret with index suffix for backward compatibility
+        for (const [key, value] of Object.entries(data)) {
+          // If key already has index suffix, use it as is, otherwise add index suffix
+          if (key.endsWith(`_${sequencerIndex}`)) {
+            l2SequencerSecrets[key] = value
+          } else {
+            l2SequencerSecrets[`${key}_${sequencerIndex}`] = value
+          }
+        }
       } else {
-        console.log(chalk.cyan(`Processing ENV secret: scroll/${secretName}`))
+        const secretName = `${baseName}-env`
+        console.log(chalk.cyan(`Processing ENV secret: ${this.pathPrefix}/${secretName}`))
         const data = await this.convertEnvToDict(path.join(secretsDir, file))
         await this.pushToVault(secretName, data)
       }
     }
 
-    // Push combined L2 Sequencer secrets
+    // Push combined L2 Sequencer secrets for backward compatibility
     if (Object.keys(l2SequencerSecrets).length > 0) {
-      console.log(chalk.cyan(`Processing combined L2 Sequencer secrets: scroll/l2-sequencer-secret-env`))
+      console.log(chalk.cyan(`Processing combined L2 Sequencer secrets: ${this.pathPrefix}/l2-sequencer-secret-env`))
       await this.pushToVault('l2-sequencer-secret-env', l2SequencerSecrets)
     }
 
@@ -336,7 +383,13 @@ export default class SetupPushSecrets extends Command {
       }),
       path: await input({
         message: chalk.cyan('Enter Vault path:'),
-        default: "scroll"
+        default: "scroll",
+        validate: (value: string) => {
+          if (/^\d+$/.test(value)) {
+            return 'Path cannot be all numeric';
+          }
+          return true;
+        }
       }),
       version: await input({
         message: chalk.cyan('Enter Vault version:'),
@@ -369,17 +422,16 @@ export default class SetupPushSecrets extends Command {
     }
   }
 
-  private async updateProductionYaml(provider: string, prefixName?: string): Promise<void> {
+  private async updateProductionYaml(provider: string, credentials: Record<string, string>): Promise<void> {
     const valuesDir = path.join(process.cwd(), this.flags['values-dir']);
     if (!fs.existsSync(valuesDir)) {
       this.error(chalk.red(`Values directory not found at ${valuesDir}`));
     }
-
-    let credentials: Record<string, string>;
+    let prefixName: string | undefined;
     if (provider === 'vault') {
-      credentials = await this.getVaultCredentials();
+      prefixName = credentials.path;
     } else {
-      credentials = await this.getAWSCredentials();
+      prefixName = credentials.prefixName;
     }
 
     const yamlFiles = fs.readdirSync(valuesDir).filter(file =>
@@ -389,6 +441,10 @@ export default class SetupPushSecrets extends Command {
     for (const yamlFile of yamlFiles) {
       const yamlPath = path.join(valuesDir, yamlFile);
       this.log(chalk.cyan(`Processing ${yamlFile}`));
+
+      // Extract sequencer index from filename if it matches the pattern
+      const sequencerMatch = yamlFile.match(/l2-sequencer-production-(\d+)\.yaml$/);
+      const sequencerIndex = sequencerMatch ? sequencerMatch[1] : null;
 
       const content = fs.readFileSync(yamlPath, 'utf8');
       const yamlContent = yaml.load(content) as any;
@@ -430,14 +486,22 @@ export default class SetupPushSecrets extends Command {
               }
             }
           }
+          // Update remoteRef.key
+          for (const data of secret.data) {
+            if (data.remoteRef && data.remoteRef.key) {
+              // Keep the standard combined path format
+              let updatedKey = "";
+              if (secretName.match(/^l2-sequencer-secret-\d+-env$/)) {
+                updatedKey = prefixName
+                  ? `${prefixName}/l2-sequencer-secret-env` : "l2-sequencer-secret-env";
+              } else {
+                updatedKey = prefixName
+                  ? `${prefixName}/${secretName}` : secretName;
+              }
 
-          // Update remoteRef for l2-sequencer secrets
-          if (secretName.match(/^l2-sequencer-secret-\d+-env$/)) {
-            for (const data of secret.data) {
-              if (data.remoteRef && data.remoteRef.key) {
-                // Use the prefixName if available
-                const prefix = prefixName || (data.remoteRef.key.startsWith('scroll/') ? 'scroll' : '');
-                data.remoteRef.key = `${prefix}/l2-sequencer-secret-env`;
+              // Only update if the key has changed
+              if (data.remoteRef.key !== updatedKey) {
+                data.remoteRef.key = updatedKey;
                 updated = true;
               }
             }
@@ -455,7 +519,6 @@ export default class SetupPushSecrets extends Command {
     }
   }
 
-
   public async run(): Promise<void> {
     const { flags } = await this.parse(SetupPushSecrets)
     this.flags = flags
@@ -472,15 +535,15 @@ export default class SetupPushSecrets extends Command {
 
     let service: SecretService
     let provider: string
-    let prefixName: string | undefined
+    let credentials: Record<string, string>
 
     if (secretService === 'aws') {
-      const awsCredentials = await this.getAWSCredentials()
-      service = new AWSSecretService(awsCredentials.secretRegion, awsCredentials.prefixName, flags.debug)
+      credentials = await this.getAWSCredentials()
+      service = new AWSSecretService(credentials.secretRegion, credentials.prefixName, flags.debug)
       provider = 'aws'
-      prefixName = awsCredentials.prefixName
     } else if (secretService === 'vault') {
-      service = new HashicorpVaultDevService(flags.debug)
+      credentials = await this.getVaultCredentials()
+      service = new HashicorpVaultDevService(flags.debug, credentials.path)
       provider = 'vault'
     } else {
       this.error(chalk.red('Invalid secret service selected'))
@@ -495,7 +558,7 @@ export default class SetupPushSecrets extends Command {
       })
 
       if (shouldUpdateYaml) {
-        await this.updateProductionYaml(provider, prefixName)
+        await this.updateProductionYaml(provider, credentials)
         this.log(chalk.green('Production YAML files updated successfully'))
       } else {
         this.log(chalk.yellow('Skipped updating production YAML files'))

--- a/src/commands/setup/verify-contracts.ts
+++ b/src/commands/setup/verify-contracts.ts
@@ -8,7 +8,7 @@ export default class ContractsVerification extends Command {
 
   static override examples = [
     '<%= config.bin %> <%= command.id %>',
-    '<%= config.bin %> <%= command.id %> --image-tag verify-9b29d9b6dcea6828118c0ee63d208095265f3a03',
+    '<%= config.bin %> <%= command.id %> --image-tag verify-f961bf3e75c7c3fec63250062e751b0aaf47fefd',
   ]
 
   static override flags = {
@@ -34,7 +34,7 @@ export default class ContractsVerification extends Command {
   }
 
   private async getDockerImageTag(providedTag: string | undefined): Promise<string> {
-    const defaultTag = 'verify-9b29d9b6dcea6828118c0ee63d208095265f3a03'
+    const defaultTag = 'verify-f961bf3e75c7c3fec63250062e751b0aaf47fefd'
 
     if (!providedTag) {
       return defaultTag


### PR DESCRIPTION
* 1. fix bug that if reexecute 'setup gen-keystore', the l2-sequencer-production-*.yaml did not get the latest data like "L2GETH_SIGNER_ADDRESS"
2. fix bug that 'setup push-secrets' did not update prefix of remoteRef.key in file 'l2-sequencer-production-*.yaml'
3. remind users that passowrd of keystore can not be empty.

* fix bug of push-secrets

* fix bug of blockscout HOST

* fix bug blockscout ingress

* fix bug blockscout INDEX_* not init

* fix bug: should auto generate values in contracts.verification

* Vault path cannot be all numeric

* update tag image and bump version