### PR TITLE
Replace l1-devnet with l1-interface rpc

### DIFF
--- a/src/commands/setup/domains.ts
+++ b/src/commands/setup/domains.ts
@@ -36,17 +36,18 @@ export default class SetupDomains extends Command {
       this.logKeyValue(key, value as string)
     }
 
-    type L1Network = 'anvil' | 'holesky' | 'mainnet' | 'other' | 'sepolia'
+    type L1Network = 'dogeos' | 'anvil' | 'holesky' | 'mainnet' | 'other' | 'sepolia'
 
     const l1Network = (await select({
       choices: [
+        { name: 'DogeOS Testnet', value: 'dogeos' },
         { name: 'Ethereum Mainnet', value: 'mainnet' },
         { name: 'Ethereum Sepolia Testnet', value: 'sepolia' },
         { name: 'Ethereum Holesky Testnet', value: 'holesky' },
         { name: 'Other...', value: 'other' },
         { name: 'Anvil (Local)', value: 'anvil' },
       ],
-      default: existingConfig.general?.CHAIN_NAME_L1?.toLowerCase() || 'mainnet',
+      default: existingConfig.general?.CHAIN_NAME_L1?.toLowerCase() || 'dogeos',
       message: 'Select the L1 network:',
     })) as L1Network
 
@@ -63,6 +64,7 @@ export default class SetupDomains extends Command {
     }
 
     const l1ChainIds: Partial<Record<L1Network, string>> = {
+      dogeos: '111111',
       anvil: '111111',
       holesky: '17000',
       mainnet: '1',
@@ -74,18 +76,17 @@ export default class SetupDomains extends Command {
     let frontendConfig: Record<string, string> = {}
 
     const usesAnvil = l1Network === 'anvil'
+    const usesDogeos = l1Network === 'dogeos'
 
-    if (l1Network === 'other' || l1Network === 'anvil') {
+    if (l1Network === 'other' || l1Network === 'anvil' || l1Network === 'dogeos') {
       generalConfig.CHAIN_NAME_L1 = await input({
-        default: existingConfig.general?.CHAIN_NAME_L1 || 'Custom L1',
+        default: existingConfig.general?.CHAIN_NAME_L1 || usesDogeos ? 'DOGE L1' : 'Custom L1',
         message: 'Enter the L1 Chain Name:',
       })
       generalConfig.CHAIN_ID_L1 = await input({
-        default: existingConfig.general?.CHAIN_ID_L1 || '',
+        default: existingConfig.general?.CHAIN_ID_L1 || l1ChainIds[l1Network] || '',
         message: 'Enter the L1 Chain ID:',
       })
-      if (l1Network !== 'anvil') {
-      }
     } else {
       generalConfig.CHAIN_NAME_L1 = l1Network.charAt(0).toUpperCase() + l1Network.slice(1)
       generalConfig.CHAIN_ID_L1 = l1ChainIds[l1Network]!
@@ -94,14 +95,14 @@ export default class SetupDomains extends Command {
     }
 
     generalConfig.CHAIN_NAME_L2 = await (input({
-      default: existingConfig.general?.CHAIN_NAME_L2 || 'Custom L2',
+      default: existingConfig.general?.CHAIN_NAME_L2 || usesDogeos ? 'DogeOS Testnet' : 'Custom L2',
       message: 'Enter the L2 Chain Name:',
     }));
 
 
 
     this.logInfo(`Using ${chalk.bold(generalConfig.CHAIN_NAME_L1)} network:`)
-    if (l1Network !== 'anvil') {
+    if (l1Network !== 'anvil' && !usesDogeos) {
       this.logKeyValue('L1 Explorer URL', domainConfig.EXTERNAL_EXPLORER_URI_L1)
       this.logKeyValue('L1 Public RPC URL', domainConfig.EXTERNAL_RPC_URI_L1)
     }
@@ -109,7 +110,11 @@ export default class SetupDomains extends Command {
     this.logKeyValue('L1 Chain Name', generalConfig.CHAIN_NAME_L1)
     this.logKeyValue('L1 Chain ID', generalConfig.CHAIN_ID_L1)
 
-    if (l1Network === 'anvil') {
+    if (usesDogeos) {
+      generalConfig.DOGEOS_L1_RPC_ENDPOINT = 'http://l1-interface:8545'
+    }
+
+    if (l1Network === 'anvil' || usesDogeos) {
       generalConfig.L1_RPC_ENDPOINT = 'http://l1-devnet:8545'
       generalConfig.L1_RPC_ENDPOINT_WEBSOCKET = 'ws://l1-devnet:8546'
     } else {
@@ -134,6 +139,9 @@ export default class SetupDomains extends Command {
       }
     }
 
+    if (usesDogeos) {
+      this.logSuccess(`Updated [general] DOGEOS_L1_RPC_ENDPOINT = "${generalConfig.DOGEOS_L1_RPC_ENDPOINT}"`)
+    }
     this.logSuccess(`Updated [general] L1_RPC_ENDPOINT = "${generalConfig.L1_RPC_ENDPOINT}"`)
     this.logSuccess(`Updated [general] L1_RPC_ENDPOINT_WEBSOCKET = "${generalConfig.L1_RPC_ENDPOINT_WEBSOCKET}"`)
 

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -36,14 +36,14 @@ export default class SetupPrepCharts extends Command {
   }
 
   private configMapping: Record<string, string | ((chartName: string, productionNumber: string) => string)> = {
-    'SCROLL_L1_RPC': 'general.L1_RPC_ENDPOINT',
+    'SCROLL_L1_RPC': 'general.DOGEOS_L1_RPC_ENDPOINT',
     'SCROLL_L2_RPC': 'general.L2_RPC_ENDPOINT',
     'CHAIN_ID': 'general.CHAIN_ID_L2',
     'CHAIN_ID_L1': 'general.CHAIN_ID_L1',
     'CHAIN_ID_L2': 'general.CHAIN_ID_L2',
-    'L2GETH_L1_ENDPOINT': 'general.L1_RPC_ENDPOINT',
+    'L2GETH_L1_ENDPOINT': 'general.DOGEOS_L1_RPC_ENDPOINT',
     'L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK': 'general.L1_CONTRACT_DEPLOYMENT_BLOCK',
-    'L1_RPC_ENDPOINT': 'general.L1_RPC_ENDPOINT',
+    'L1_RPC_ENDPOINT': 'general.DOGEOS_L1_RPC_ENDPOINT',
     'L2_RPC_ENDPOINT': 'general.L2_RPC_ENDPOINT',
     'L1_SCROLL_CHAIN_PROXY_ADDR': 'contractsFile.L1_SCROLL_CHAIN_PROXY_ADDR',
     'L2GETH_SIGNER_ADDRESS': (chartName, productionNumber) =>
@@ -324,10 +324,11 @@ export default class SetupPrepCharts extends Command {
                 }
 
                 let configValue = this.getConfigValue(configKey)
-                if (this.isL2Node(chartName)) {
-                  if (key === "L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK") {
-                    configValue = this.dogeConfig.defaults?.dogecoinIndexerStartHeight;
-                  }
+                if (this.isL2Node(chartName) && key === "L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK") {
+                  configValue = this.dogeConfig.defaults?.dogecoinIndexerStartHeight;
+                }
+                if ((chartName === "rollup-node" || chartName === "contracts") && key === "L1_RPC_ENDPOINT") {
+                  configValue = this.getConfigValue("general.L1_RPC_ENDPOINT");
                 }
                 if (configValue !== undefined && configValue !== null) {
                   let newValue: string | string[]
@@ -571,7 +572,7 @@ export default class SetupPrepCharts extends Command {
           },
           {
             key: 'INDEXER_SCROLL_L1_RPC',
-            configKey: 'general.L1_RPC_ENDPOINT'
+            configKey: 'general.DOGEOS_L1_RPC_ENDPOINT'
           }
 
 
@@ -718,6 +719,7 @@ export default class SetupPrepCharts extends Command {
           "DOGEOS_L1_INTERFACE_SCROLL_MESSENGER_ADDRESS": this.getConfigValue("contractsFile.L1_SCROLL_MESSENGER_PROXY_ADDR"),
           "DOGEOS_L1_INTERFACE_L1_GENESIS_BLOCK": this.dogeConfig.defaults?.dogecoinIndexerStartHeight,
           "DOGEOS_L1_INTERFACE_L2_MOAT_CONTRACT_ADDRESS": this.getConfigValue("contractsFile.L2_MOAT_PROXY_ADDR"),
+          "DOGEOS_L1_INTERFACE_L2_MESSENGER_ADDRESS": this.getConfigValue("contractsFile.L2_DOGEOS_MESSENGER_PROXY_ADDR"),
           "DOGEOS_L1_INTERFACE_L1_BASE_FEE_PER_GAS": this.getConfigValue("genesis.BASE_FEE_PER_GAS").toString(),
           "DOGEOS_L1_INTERFACE_INITIAL_SYSTEM_SIGNER": this.getConfigValue("sequencer.L2GETH_SIGNER_ADDRESS"),
           "DOGEOS_L1_INTERFACE_DOGECOIN_RPC__URL": dogecoinInternalUrl,
@@ -940,10 +942,12 @@ export default class SetupPrepCharts extends Command {
       else if (chartName == "metrics-exporter") {
 
         const rollupExplorerBackendUrl = "http://rollup-explorer-backend";
-        const l1MessageQueueProxyAddr = this.getConfigValue("contractsFile.L1_MESSAGE_QUEUE_V2_PROXY_ADDR");
         const l2RpcEndpoint = this.getConfigValue("general.L2_RPC_ENDPOINT");
         const l2TxFeeVaultAddr = this.getConfigValue("contracts.overrides.L2_TX_FEE_VAULT");
         const l2BridgeFeeRecipientAddr = this.getConfigValue("contracts.L2_BRIDGE_FEE_RECIPIENT_ADDR");
+        const isDogeos = this.getConfigValue("general.DOGEOS_L1_RPC_ENDPOINT") === "http://l1-interface:8545";
+        const l1MessageQueueProxyAddr = isDogeos ? "" : this.getConfigValue("contractsFile.L1_MESSAGE_QUEUE_V2_PROXY_ADDR");
+        const l1RpcEndpoint = this.getConfigValue(isDogeos ? "general.DOGEOS_L1_RPC_ENDPOINT" : "general.L1_RPC_ENDPOINT");
 
         if (!productionYaml.metricsConfig) {
           productionYaml.metricsConfig = {
@@ -951,7 +955,7 @@ export default class SetupPrepCharts extends Command {
               url: rollupExplorerBackendUrl
             },
             l1Network: {
-              url: this.getConfigValue("general.L1_RPC_ENDPOINT"),
+              url: l1RpcEndpoint,
               L1_MESSAGE_QUEUE_PROXY_ADDR: l1MessageQueueProxyAddr
             },
             dogecoin: {
@@ -977,13 +981,13 @@ export default class SetupPrepCharts extends Command {
             });
             productionYaml.metricsConfig.rollup.url = rollupExplorerBackendUrl;
           }
-          if (productionYaml.metricsConfig.l1Network.url != this.getConfigValue("general.L1_RPC_ENDPOINT")) {
+          if (productionYaml.metricsConfig.l1Network.url != l1RpcEndpoint) {
             updated = true;
             changes.push({
               key: `metricsConfig.l1Network.url`, oldValue: productionYaml.metricsConfig.l1Network.url,
-              newValue: this.getConfigValue("general.L1_RPC_ENDPOINT")
+              newValue: l1RpcEndpoint
             });
-            productionYaml.metricsConfig.l1Network.url = this.getConfigValue("general.L1_RPC_ENDPOINT");
+            productionYaml.metricsConfig.l1Network.url = l1RpcEndpoint;
           }
           if (productionYaml.metricsConfig.l1Network.L1_MESSAGE_QUEUE_PROXY_ADDR != l1MessageQueueProxyAddr) {
             updated = true;


### PR DESCRIPTION
* Replace l1-devnet RPC with l1-interface in most of the services, e.g. l2-sequencer, l2-rpc, l2-bootnode, etc.

* not changed for the following two services:
1. rollup-node
2. contracts

* Not changed in scroll-sdk-cli commands:
1. helper activity
2. helper fund-accounts
3. gen-rpc
4. test contracts
5. test e2e