### PR TITLE
Use internal blockbook service for l1-interface and withdrawal-processor

### DIFF
--- a/src/commands/doge/config.ts
+++ b/src/commands/doge/config.ts
@@ -235,7 +235,7 @@ export class DogeConfigCommand extends Command {
         password: '',
         apiKey: '',
         blockbookAPIUrl:
-          network === 'mainnet' ? 'https://dogebook.nownodes.io/api/v2' : 'https://dogebook-testnet.nownodes.io/api/v2',
+          network === 'mainnet' ? 'http://blockbook-mainnet:19139' : 'http://blockbook-testnet:19139',
         url: network === 'mainnet' ? 'https://dogecoin.mainnet.dogeos.com' : 'https://dogecoin.testnet.dogeos.com',
       },
       dogecoinClusterRpc: {
@@ -286,9 +286,18 @@ export class DogeConfigCommand extends Command {
 
     let newConfig = existingConfig;
 
+    // Handle blockbook API URL with confirmation if different from default
+    const defaultBlockbookUrl = network === 'mainnet' ? 'http://blockbook-mainnet:19139' : 'http://blockbook-testnet:19139'
+    const currentBlockbookUrl = existingConfig.rpc?.blockbookAPIUrl || defaultBlockbookUrl
+    
+    newConfig.rpc!.blockbookAPIUrl = await input({
+      default: currentBlockbookUrl,
+      message: `Enter Internal Blockbook API URL:`,
+    });
+
     newConfig.rpc!.apiKey = await input({
       default: existingConfig.rpc?.apiKey,
-      message: 'Enter your NowNodes API key (get one at nownodes.io):',
+      message: 'Enter your NowNodes API key (deployment only, get one at nownodes.io):',
       validate: (value) => (value ? true : 'API key is required'),
     })
 
@@ -600,8 +609,7 @@ export class DogeConfigCommand extends Command {
     newConfig.dogecoin_rpc_url = newDogeConfig.rpc?.url || '';
     newConfig.dogecoin_rpc_user = newDogeConfig.rpc?.username || '';
     newConfig.dogecoin_rpc_pass = newDogeConfig.rpc?.password || '';
-    const blockbookUrl = newDogeConfig.rpc?.blockbookAPIUrl?.replace('/api/v2', '') || '';
-    newConfig.dogecoin_blockbook_url = blockbookUrl;
+    newConfig.dogecoin_blockbook_url = newConfig.network === 'mainnet' ? 'https://dogebook.nownodes.io' : 'https://dogebook-testnet.nownodes.io';
     newConfig.dogecoin_blockbook_api_key = newDogeConfig.rpc?.apiKey || '';
 
     // Write to setup_defaults.toml

--- a/src/commands/setup/configs.ts
+++ b/src/commands/setup/configs.ts
@@ -161,7 +161,7 @@ export default class SetupConfigs extends Command {
       'dogecoin',
       'testnet-activity-helper',
       'l1-interface',
-      // 'dogeos-deposit-processor',
+      'blockbook',
       'dogecoin',
       'withdrawal-processor',
       'metrics-exporter',
@@ -322,6 +322,10 @@ export default class SetupConfigs extends Command {
         'DOGECOIN_RPC_USER:DOGECOIN_RPC_USER',
         'DOGECOIN_RPC_PASSWORD:DOGECOIN_RPC_PASSWORD',
       ],
+      'blockbook': [
+        'DOGECOIN_RPC_USER:DOGECOIN_RPC_USER',
+        'DOGECOIN_RPC_PASSWORD:DOGECOIN_RPC_PASSWORD',
+      ],
       'withdrawal-processor': [
       ],
       'contracts': [
@@ -414,15 +418,13 @@ export default class SetupConfigs extends Command {
     if (service === 'l1-interface') {
       let content = `DOGEOS_L1_INTERFACE_DOGECOIN_RPC__USER="${this.dogeConfig.dogecoinClusterRpc?.username || ''}"\n`
       content += `DOGEOS_L1_INTERFACE_DOGECOIN_RPC__PASS="${this.dogeConfig.dogecoinClusterRpc?.password || ''}"\n`
-      content += `DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY="${this.dogeConfig.rpc?.apiKey || ''}"\n`
+      content += `DOGEOS_L1_INTERFACE_DOGECOIN_RPC__BLOCKBOOK_API_KEY=""\n`
       envFiles['l1-interface-secret.env'] = content
     }
 
-    if (service === 'dogeos-deposit-processor') {
-      envFiles['dogeos-deposit-processor-secret.env'] = `DOGEOS_DEPOSIT_PROCESSOR_NOWNODES_API_KEY="${this.dogeConfig.rpc?.apiKey}"\n`
-      //not used for now
-      // envFiles['dogeos-deposit-processor-secret.env']+=`username="${this.dogeConfig.rpc?.username}"\n`
-      // envFiles['dogeos-deposit-processor-secret.env']+=`password="${this.dogeConfig.rpc?.password}"\n`
+    if (service === 'blockbook') {
+      envFiles['blockbook-secret.env'] = `DOGECOIN_RPC_USER="${this.dogeConfig.dogecoinClusterRpc?.username || ''}"\n`
+      envFiles['blockbook-secret.env'] += `DOGECOIN_RPC_PASSWORD="${this.dogeConfig.dogecoinClusterRpc?.password || ''}"\n`
     }
 
     if (service === 'dogecoin') {
@@ -443,11 +445,11 @@ export default class SetupConfigs extends Command {
       content += `DOGEOS_WITHDRAWAL_CELESTIA_INDEXER__TENDERMINT_RPC_URL="${this.dogeConfig.da?.tendermintRpcUrl || ''}"\n`
 
       // Add blockbook API key from doge-config if available
-      if (this.dogeConfig.rpc?.apiKey) {
-        content += `DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY="${this.dogeConfig.rpc?.apiKey}"\n`
-      } else {
-        this.error(`dogeConfig.rpc?.apiKey is null`)
-      }
+      // if (this.dogeConfig.rpc?.apiKey) {
+      //   content += `DOGEOS_WITHDRAWAL_BLOCKBOOK_API_KEY="${this.dogeConfig.rpc?.apiKey}"\n`
+      // } else {
+      //   this.error(`dogeConfig.rpc?.apiKey is null`)
+      // }
 
       // Add values from output-withdrawal-processor.toml
       const withdrawal_processor_toml_path = path.join(process.cwd(), ".data", "output-withdrawal-processor.toml");

--- a/src/commands/setup/domains.ts
+++ b/src/commands/setup/domains.ts
@@ -365,6 +365,7 @@ export default class SetupDomains extends Command {
         TSO_HOST: `tso.${urlEnding}`,
         CELESTIA_HOST: `celestia.${urlEnding}`,
         DOGECOIN_HOST: `dogecoin.${urlEnding}`,
+        BLOCKBOOK_HOST: `blockbook.${urlEnding}`,
       }
     } else {
       protocol = await select({
@@ -424,6 +425,10 @@ export default class SetupDomains extends Command {
         DOGECOIN_HOST: await input({
           default: existingConfig.ingress?.DOGECOIN_HOST || 'dogecoin.scrollsdk',
           message: 'Enter DOGECOIN_HOST:',
+        }),
+        BLOCKBOOK_HOST: await input({
+          default: existingConfig.ingress?.BLOCKBOOK_HOST || 'blockbook.scrollsdk',
+          message: 'Enter BLOCKBOOK_HOST:',
         }),
       }
 

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -187,7 +187,12 @@ export default class SetupPrepCharts extends Command {
       if (urlObj.pathname.endsWith('/api/v2')) {
         urlObj.pathname = urlObj.pathname.slice(0, -7) + '/api';
       }
-      return urlObj.toString();
+      let urlString = urlObj.toString();
+      // Remove trailing slash if it exists
+      if (urlString.endsWith('/')) {
+        urlString = urlString.slice(0, -1);
+      }
+      return urlString;
     } catch {
       return url;
     }
@@ -386,6 +391,7 @@ export default class SetupPrepCharts extends Command {
                         'tso-service': 'TSO_HOST',
                         'celestia-node': 'CELESTIA_HOST',
                         'dogecoin': 'DOGECOIN_HOST',
+                        'blockbook': 'BLOCKBOOK_HOST',
                       };
 
                       const alternativeKey = alternativeMappings[chartName];
@@ -709,6 +715,43 @@ export default class SetupPrepCharts extends Command {
         if (ingressUpdated) {
           updated = true;
         }
+      } else if (chartName == 'blockbook') {
+        let ingressUpdated = false;
+        if (!productionYaml.ingress) {
+          productionYaml.ingress = {
+            enabled: true,
+            className: "nginx",
+            annotations: {
+              "cert-manager.io/cluster-issuer": "letsencrypt-prod",
+              "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+            },
+            hosts: [
+              {
+                host: this.getConfigValue("ingress.BLOCKBOOK_HOST"),
+                paths: [{ path: "/", pathType: "Prefix" }]
+              }
+            ],
+          };
+          changes.push({ key: `ingress`, oldValue: "undefined", newValue: JSON.stringify(productionYaml.ingress) });
+          ingressUpdated = true;
+        } else {
+          let ingressValue = productionYaml.ingress;
+          ingressValue.enabled = true;
+          const configValue = this.getConfigValue('ingress.BLOCKBOOK_HOST');
+          ingressUpdated = this.processIngressHosts(ingressValue, configValue, changes);
+        }
+
+        if (ingressUpdated) {
+          updated = true;
+        }
+
+        const oldValue = productionYaml.blockbook.blockHeight;
+        const newValue = this.dogeConfig.defaults?.dogecoinIndexerStartHeight;
+        if (oldValue !== newValue) {
+          productionYaml.blockbook.blockHeight = this.dogeConfig.defaults?.dogecoinIndexerStartHeight;
+          updated = true;
+          changes.push({ key: `blockbook.blockHeight`, oldValue: oldValue || 'undefined', newValue: newValue || 'undefined' });
+        }
       }
 
       else if (chartName == 'fee-oracle') {
@@ -924,33 +967,33 @@ configMaps:
           }
         }
       }
-      else if (chartName == "dogeos-deposit-processor") {
-        // Check and ensure configMaps.env.data exists
-        if (!productionYaml.configMaps?.env?.data) {
-          this.warn(`${chartName}: configMaps.env.data not found, skipping configuration update`);
-          continue;
-        }
-        let blockbookUrl = this.getBaseUrl(this.dogeConfig.rpc?.blockbookAPIUrl);
-        if (blockbookUrl?.endsWith('/api')) {
-          blockbookUrl = blockbookUrl.slice(0, -4);
-        }
-        const depositProcessorMappings = {
-          'DOGEOS_DEPOSIT_PROCESSOR_DOGE_RPC_URL': blockbookUrl,
-          'DOGEOS_DEPOSIT_PROCESSOR_DEPOSIT_DOGE_ADDRESS': this.withdrawalProcessorConfig["bridge_address"],
-          'DOGEOS_DEPOSIT_PROCESSOR_MOAT_ADDRESS': this.getConfigValue("contractsFile.L2_MOAT_PROXY_ADDR"),
-          'DOGEOS_DEPOSIT_PROCESSOR_ANVIL_RPC_URL': this.getConfigValue("general.L1_RPC_ENDPOINT"),
-          'DOGEOS_DEPOSIT_PROCESSOR_L1_MESSENGER_ADDRESS': this.getConfigValue("contractsFile.L1_SCROLL_MESSENGER_PROXY_ADDR")
-        };
+      // else if (chartName == "dogeos-deposit-processor") {
+      //   // Check and ensure configMaps.env.data exists
+      //   if (!productionYaml.configMaps?.env?.data) {
+      //     this.warn(`${chartName}: configMaps.env.data not found, skipping configuration update`);
+      //     continue;
+      //   }
+      //   let blockbookUrl = this.getBaseUrl(this.dogeConfig.rpc?.blockbookAPIUrl);
+      //   if (blockbookUrl?.endsWith('/api')) {
+      //     blockbookUrl = blockbookUrl.slice(0, -4);
+      //   }
+      //   const depositProcessorMappings = {
+      //     'DOGEOS_DEPOSIT_PROCESSOR_DOGE_RPC_URL': blockbookUrl,
+      //     'DOGEOS_DEPOSIT_PROCESSOR_DEPOSIT_DOGE_ADDRESS': this.withdrawalProcessorConfig["bridge_address"],
+      //     'DOGEOS_DEPOSIT_PROCESSOR_MOAT_ADDRESS': this.getConfigValue("contractsFile.L2_MOAT_PROXY_ADDR"),
+      //     'DOGEOS_DEPOSIT_PROCESSOR_ANVIL_RPC_URL': this.getConfigValue("general.L1_RPC_ENDPOINT"),
+      //     'DOGEOS_DEPOSIT_PROCESSOR_L1_MESSENGER_ADDRESS': this.getConfigValue("contractsFile.L1_SCROLL_MESSENGER_PROXY_ADDR")
+      //   };
 
-        for (const [envKey, newValue] of Object.entries(depositProcessorMappings)) {
-          if (newValue !== undefined && productionYaml.configMaps.env.data[envKey] !== newValue) {
-            const oldValue = productionYaml.configMaps.env.data[envKey];
-            productionYaml.configMaps.env.data[envKey] = newValue;
-            updated = true;
-            changes.push({ key: `configMaps.env.data["${envKey}"]`, oldValue, newValue });
-          }
-        }
-      }
+      //   for (const [envKey, newValue] of Object.entries(depositProcessorMappings)) {
+      //     if (newValue !== undefined && productionYaml.configMaps.env.data[envKey] !== newValue) {
+      //       const oldValue = productionYaml.configMaps.env.data[envKey];
+      //       productionYaml.configMaps.env.data[envKey] = newValue;
+      //       updated = true;
+      //       changes.push({ key: `configMaps.env.data["${envKey}"]`, oldValue, newValue });
+      //     }
+      //   }
+      // }
       else if (chartName == "tso-service") {
         if (!productionYaml.env) {
           this.error(`${chartName}: env not found in config`);
@@ -1191,12 +1234,27 @@ configMaps:
           this.error(chalk.red(`Failed to parse scrollConfig JSON in ${file}: ` + e.message));
         }
         
+        const currentL1Endpoint = scrollConfigJson["l1_config"]["endpoint"];
+        if (currentL1Endpoint != "") {
+          scrollConfigJson["l1_config"]["endpoint"] = "";
+          updated = true;
+          changes.push({ key: `l1_config.endpoint`, oldValue: currentL1Endpoint, newValue: "" });
+        }
         const currentEndpoint = scrollConfigJson["l2_config"]["relayer_config"]["sender_config"]["endpoint"];
         if (currentEndpoint != daPublisherEndpoint) {
           scrollConfigJson["l2_config"]["relayer_config"]["sender_config"]["endpoint"] = daPublisherEndpoint;
           updated = true;
           changes.push({ key: `l2_config.relayer_config.sender_config.endpoint`, oldValue: currentEndpoint, newValue: daPublisherEndpoint });
         }
+        
+        // Remove celestia_submit_endpoint if it exists
+        if (scrollConfigJson["l2_config"]?.["relayer_config"]?.["celestia_submit_endpoint"] !== undefined) {
+          const currentCelestiaEndpoint = scrollConfigJson["l2_config"]["relayer_config"]["celestia_submit_endpoint"];
+          delete scrollConfigJson["l2_config"]["relayer_config"]["celestia_submit_endpoint"];
+          updated = true;
+          changes.push({ key: `l2_config.relayer_config.celestia_submit_endpoint`, oldValue: currentCelestiaEndpoint, newValue: "removed" });
+        }
+        
 
         if (updated) {
           this.log(`\nFor ${chalk.cyan(file)}:`)

--- a/src/commands/setup/tls.ts
+++ b/src/commands/setup/tls.ts
@@ -272,6 +272,13 @@ spec:
             updated = true;
           }
         }
+      } else if (chart == "blockbook") {
+        if (yamlContent.ingress) {
+          const blockbookUpdated = this.processStandardTls(yamlContent, chart, issuer);
+          if (blockbookUpdated) {
+            updated = true;
+          }
+        }
       }
 
       for (const ingressType of ingressTypes) {
@@ -415,7 +422,7 @@ spec:
         'tso-service',
         'celestia-node',
         'dogecoin',
-        //'withdrawal-processor' //no ingress in withdrawal-processor  
+        'blockbook'
       ]
 
       for (const chart of chartsToUpdate) {


### PR DESCRIPTION
1. use secret for dogecoin rpc user/password in blockbook service
2. leave empty of l1_config.endpoint in rollup-config.yaml
3. use internal blockbook service for l1-interface and withdrawal-processor

note: NowNodes API KEY is still required during bridge initialization.