### PR TITLE
DOG-382: Align DogeOS runtime service configs

### DIFF
--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -542,11 +542,13 @@ export function validateDogeConfigEthereumDaForPrep(ethereumDa: DogeConfig['ethe
 
 export function buildL1InterfaceBlobSourcePrepEnv(input: {
   beaconRpcUrl: string | undefined
+  s3KeyPrefix?: string | undefined
   s3PublicBaseUrl?: string | undefined
   s3TimeoutMs?: boolean | number | string | undefined
   s3TreatForbiddenAsMissing?: boolean | number | string | undefined
 }): Record<string, string | undefined> {
   return {
+    DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX: optionalConfigString(input.s3KeyPrefix),
     DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS: optionalConfigString(input.s3TimeoutMs),
     DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING: optionalConfigString(input.s3TreatForbiddenAsMissing),
     DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL: optionalConfigString(input.s3PublicBaseUrl),
@@ -557,11 +559,13 @@ export function buildL1InterfaceBlobSourcePrepEnv(input: {
 
 export function buildWithdrawalBlobSourcePrepEnv(input: {
   beaconRpcUrl: string | undefined
+  s3KeyPrefix?: string | undefined
   s3PublicBaseUrl?: string | undefined
   s3TimeoutMs?: boolean | number | string | undefined
   s3TreatForbiddenAsMissing?: boolean | number | string | undefined
 }): Record<string, string | undefined> {
   return {
+    DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX: optionalConfigString(input.s3KeyPrefix),
     DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS: optionalConfigString(input.s3TimeoutMs),
     DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING: optionalConfigString(input.s3TreatForbiddenAsMissing),
     DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL: optionalConfigString(input.s3PublicBaseUrl),
@@ -1776,6 +1780,7 @@ export default class SetupPrepCharts extends Command {
           ...todoMappings,
           ...buildL1InterfaceBlobSourcePrepEnv({
             beaconRpcUrl: this.getConfigValue("ethereumDa.beaconRpcUrl"),
+            s3KeyPrefix: s3ArchiveEnabled ? s3Archive?.keyPrefix : undefined,
             s3PublicBaseUrl: s3ArchiveEnabled ? s3Archive?.publicBaseUrl : undefined,
             s3TimeoutMs: s3ArchiveEnabled ? s3Archive?.timeoutMs : undefined,
             s3TreatForbiddenAsMissing: s3ArchiveEnabled ? s3Archive?.treatForbiddenAsMissing : undefined,
@@ -1825,6 +1830,7 @@ export default class SetupPrepCharts extends Command {
           "DOGEOS_WITHDRAWAL_ETHEREUM_DA__MIN_FINALITY": this.getConfigValue("ethereumDa.minFinality"),
           ...buildWithdrawalBlobSourcePrepEnv({
             beaconRpcUrl: this.getConfigValue("ethereumDa.beaconRpcUrl"),
+            s3KeyPrefix: s3ArchiveEnabled ? s3Archive?.keyPrefix : undefined,
             s3PublicBaseUrl: s3ArchiveEnabled ? s3Archive?.publicBaseUrl : undefined,
             s3TimeoutMs: s3ArchiveEnabled ? s3Archive?.timeoutMs : undefined,
             s3TreatForbiddenAsMissing: s3ArchiveEnabled ? s3Archive?.treatForbiddenAsMissing : undefined,

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -73,6 +73,8 @@ export interface PrepChartChange {
   oldValue: string
 }
 
+const ETH_DA_ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
 const FEE_ORACLE_LEGACY_CONFIGMAP_PREFIXES = [
   'DOGEOS_FEE_ORACLE_DOGECOIN__',
   'DOGEOS_FEE_ORACLE_CELESTIA__',
@@ -193,9 +195,34 @@ export function buildFeeOraclePrepEnv(input: {
   l2RpcUrl: string | undefined
 }): Record<string, string | undefined> {
   return {
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__ADVANCE_L2__MAX_L2_PAYLOAD_BYTES_PER_ADVANCE_L2: '90000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__ADVANCE_L2__MAX_SOURCE_AGE_SECONDS: '300',
     DOGEOS_FEE_ORACLE_ETHEREUM_DA__CONTRACT_WRITE_MODE: 'dry_run',
     DOGEOS_FEE_ORACLE_ETHEREUM_DA__ETH_RPC_URL: input.ethereumDaRpcUrl,
-    DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI: '"0"',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__EXECUTION_GAS_FLOOR: '21000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__EXECUTION_GAS_SOURCE: 'conceptual_floor',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_LIMIT_SAFETY_MARGIN: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__FORMULA: 'galileo',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__PRECISION_DEC: '1000000000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__SCALAR_POLICY: 'static_verified',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__MAX_BLOBS_PER_TX: '6',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRICES__MAX_QUOTE_AGE_SECONDS: '60',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRICES__MIN_SOURCE_QUORUM: '2',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRIORITY_FEE_SOURCE: 'configured_min',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__SAMPLE_INTERVAL_SECONDS: '30',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__SAMPLE_STALE_AFTER_SECONDS: '90',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__TARGET_BLOBS_PER_TX: '2',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ADVANCE_L2_STALE_FALLBACK: 'not_ready',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__FIRST_VALID_ORACLE_VALUES: 'update',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__FORCE_UPDATE_AFTER_SECONDS: '3600',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__MAX_ORACLE_VALUE_AGE_SECONDS: '1800',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ORACLE_VALUE_STAT: 'median',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ORACLE_VALUE_WINDOW_SECONDS: '300',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__PRICE_UNAVAILABLE_FALLBACK: 'hold_last',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__RELATIVE_DELTA_THRESHOLD_PPM__BASE_FEE_PER_GAS: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__RELATIVE_DELTA_THRESHOLD_PPM__BLOB_BASE_FEE_PER_BLOB_GAS: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__SUBMITTER_DEFERRED_FALLBACK: 'hold_last',
     DOGEOS_FEE_ORACLE_L2__CHAIN_ID: input.l2ChainId === undefined ? undefined : String(input.l2ChainId),
     DOGEOS_FEE_ORACLE_L2__GAS_ORACLE_CONTRACT: input.gasOracleContract,
     DOGEOS_FEE_ORACLE_L2__RPC_URL: input.l2RpcUrl,
@@ -204,15 +231,19 @@ export function buildFeeOraclePrepEnv(input: {
 }
 
 export function buildEthDaSubmitterPrepEnv(input: {
+  batch?: NonNullable<NonNullable<DogeConfig['ethereumDa']>['batch']> | undefined
   ethereumChainId: number | string | undefined
   ethereumRpcUrl: string | undefined
   l2ChainId: number | string | undefined
   l2RpcUrl: string | undefined
+  l2StartBlockNumber?: number | string | undefined
+  publish?: NonNullable<NonNullable<DogeConfig['ethereumDa']>['publish']> | undefined
   s3Bucket?: string | undefined
   s3Enabled?: boolean | string | undefined
   s3EndpointUrl?: string | undefined
   s3ForcePathStyle?: boolean | string | undefined
   s3InitialBackoffMs?: number | string | undefined
+  s3KeyPrefix?: string | undefined
   s3MaxBackoffMs?: number | string | undefined
   s3MaxRetries?: number | string | undefined
   s3PollIntervalMs?: number | string | undefined
@@ -224,6 +255,50 @@ export function buildEthDaSubmitterPrepEnv(input: {
     DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__L2_CHAIN_ID: input.l2ChainId === undefined ? undefined : String(input.l2ChainId),
     DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__RPC_URL: input.ethereumRpcUrl,
     DOGEOS_ETH_DA_SUBMITTER_L2__RPC_URL: input.l2RpcUrl,
+    DOGEOS_ETH_DA_SUBMITTER_L2__START_BLOCK_NUMBER: optionalConfigString(input.l2StartBlockNumber),
+  }
+
+  const {batch} = input
+  if (batch) {
+    const {cutover} = batch
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__COMPRESSION = optionalConfigString(batch.compression) ?? 'auto'
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_BATCH_HASH = optionalConfigString(batch.genesisBatchHash) ?? optionalConfigString(cutover?.lastBatchHash) ?? ETH_DA_ZERO_HASH
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_RELAYED_DEPOSIT_INDEX = String(batch.genesisNextRelayedDepositIndex ?? cutover?.nextRelayedDepositIndex ?? 0)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_WITHDRAW_INDEX = String(batch.genesisNextWithdrawIndex ?? cutover?.nextWithdrawIndex ?? 0)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_RELAYED_DEPOSIT_QUEUE_HASH = optionalConfigString(batch.genesisRelayedDepositQueueHash) ?? optionalConfigString(cutover?.relayedDepositQueueHash) ?? ETH_DA_ZERO_HASH
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_STATE_ROOT = optionalConfigString(batch.genesisStateRoot) ?? optionalConfigString(cutover?.stateRoot) ?? ETH_DA_ZERO_HASH
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_WITHDRAW_ROOT = optionalConfigString(batch.genesisWithdrawRoot) ?? optionalConfigString(cutover?.withdrawRoot) ?? ETH_DA_ZERO_HASH
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_BLOCKS_PER_CHUNK = String(batch.maxBlocksPerChunk ?? 128)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_CHUNKS_PER_BATCH = String(batch.maxChunksPerBatch ?? 1)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_L2_GAS_PER_CHUNK = String(batch.maxL2GasPerChunk ?? 6_000_000)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_UNCOMPRESSED_BATCH_BYTES_SIZE = String(batch.maxUncompressedBatchBytesSize ?? 131_072)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MIN_CODEC_VERSION = String(batch.minCodecVersion ?? 10)
+
+    if (normalizeInitialBatchSidecarJson(batch.initialBatchSidecarJson)) {
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__INITIAL_BATCH_SIDECAR_JSON = '/app/config/initial_batch.json'
+    }
+
+    if (cutover) {
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_HASH = optionalConfigString(cutover.lastBatchHash)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_INDEX = optionalConfigString(cutover.lastBatchIndex)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__NEXT_RELAYED_DEPOSIT_INDEX = optionalConfigString(cutover.nextRelayedDepositIndex)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__NEXT_WITHDRAW_INDEX = optionalConfigString(cutover.nextWithdrawIndex)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__RELAYED_DEPOSIT_QUEUE_HASH = optionalConfigString(cutover.relayedDepositQueueHash)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__STATE_ROOT = optionalConfigString(cutover.stateRoot)
+      env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__WITHDRAW_ROOT = optionalConfigString(cutover.withdrawRoot)
+    }
+  }
+
+  const {publish} = input
+  if (publish) {
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__ALLOW_LIVENESS_BUDGET_OVERRIDE = optionalConfigString(publish.allowLivenessBudgetOverride)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__BUDGET_WINDOW = optionalConfigString(publish.budgetWindow)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__HIGH_BACKLOG_THRESHOLD = optionalConfigString(publish.highBacklogThreshold)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_BATCH_WAIT = optionalConfigString(publish.maxBatchWait)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_BLOBS_PER_TX = optionalConfigString(publish.maxBlobsPerTx)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_LIVENESS_DELAY = optionalConfigString(publish.maxLivenessDelay)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_PENDING_BLOB_TXS = optionalConfigString(publish.maxPendingBlobTxs)
+    env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__TARGET_BLOBS_PER_TX = optionalConfigString(publish.targetBlobsPerTx)
   }
 
   if (input.s3Enabled !== undefined) {
@@ -233,6 +308,7 @@ export function buildEthDaSubmitterPrepEnv(input: {
     if (s3Enabled) {
       env.DOGEOS_ETH_DA_SUBMITTER_S3__BUCKET = optionalConfigString(input.s3Bucket)
       env.DOGEOS_ETH_DA_SUBMITTER_S3__REGION = optionalConfigString(input.s3Region)
+      env.DOGEOS_ETH_DA_SUBMITTER_S3__KEY_PREFIX = optionalConfigString(input.s3KeyPrefix)
       env.DOGEOS_ETH_DA_SUBMITTER_S3__ENDPOINT_URL = optionalConfigString(input.s3EndpointUrl)
       env.DOGEOS_ETH_DA_SUBMITTER_S3__FORCE_PATH_STYLE = optionalConfigString(input.s3ForcePathStyle)
       env.DOGEOS_ETH_DA_SUBMITTER_S3__POLL_INTERVAL_MS = optionalConfigString(input.s3PollIntervalMs)
@@ -243,17 +319,225 @@ export function buildEthDaSubmitterPrepEnv(input: {
     }
   }
 
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete env[key]
+    }
+  }
+
   return env
+}
+
+export function applyEthDaSubmitterInitialBatchSidecar(
+  productionYaml: any,
+  initialBatchSidecarJson: string | undefined
+): PrepChartChange[] {
+  const changes: PrepChartChange[] = []
+  const sidecarJson = normalizeInitialBatchSidecarJson(initialBatchSidecarJson)
+  if (!sidecarJson) return changes
+
+  productionYaml.configMaps ||= {}
+  productionYaml.configMaps['initial-batch'] ||= {}
+  const initialBatchConfigMap = productionYaml.configMaps['initial-batch']
+  const nextConfigMap = {
+    ...initialBatchConfigMap,
+    data: {
+      ...initialBatchConfigMap.data,
+      'initial_batch.json': sidecarJson,
+    },
+    enabled: true,
+  }
+  const previousConfigMap = JSON.stringify(initialBatchConfigMap)
+  productionYaml.configMaps['initial-batch'] = nextConfigMap
+  const currentConfigMap = JSON.stringify(nextConfigMap)
+  if (previousConfigMap !== currentConfigMap) {
+    changes.push({
+      key: 'configMaps.initial-batch',
+      newValue: currentConfigMap,
+      oldValue: previousConfigMap,
+    })
+  }
+
+  productionYaml.persistence ||= {}
+  const previousPersistence = JSON.stringify(productionYaml.persistence['initial-batch'])
+  productionYaml.persistence['initial-batch'] = {
+    enabled: true,
+    items: [{ key: 'initial_batch.json', path: 'initial_batch.json' }],
+    mountPath: '/app/config',
+    name: '{{ include "scroll.common.lib.chart.names.fullname" . }}-initial-batch',
+    readOnly: true,
+    type: 'configMap',
+  }
+  const currentPersistence = JSON.stringify(productionYaml.persistence['initial-batch'])
+  if (previousPersistence !== currentPersistence) {
+    changes.push({
+      key: 'persistence.initial-batch',
+      newValue: currentPersistence,
+      oldValue: previousPersistence || 'undefined',
+    })
+  }
+
+  return changes
 }
 
 function truthyConfigValue(value: unknown): boolean {
   return value === true || (typeof value === 'string' && value.toLowerCase() === 'true')
 }
 
+function isConfiguredValue(value: unknown): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== ''
+}
+
 function optionalConfigString(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined
   const stringValue = String(value)
   return stringValue.trim() === '' ? undefined : stringValue
+}
+
+function normalizeInitialBatchSidecarJson(value: string | undefined): string | undefined {
+  const stringValue = optionalConfigString(value)
+  if (!stringValue) return undefined
+  const trimmed = stringValue.trim()
+  try {
+    JSON.parse(trimmed)
+  } catch {
+    throw new Error('ethereumDa.batch.initialBatchSidecarJson must be valid JSON')
+  }
+
+  return trimmed
+}
+
+function pushConfigValidationError(errors: string[], path: string, message: string): void {
+  errors.push(`${path}: ${message}`)
+}
+
+function validateOptionalBytes32Config(errors: string[], path: string, value: unknown): void {
+  if (value === undefined || value === null) return
+  if (!/^0x[\dA-Fa-f]{64}$/.test(String(value))) {
+    pushConfigValidationError(errors, path, 'must be a 32-byte 0x-prefixed hex string')
+  }
+}
+
+function validateRequiredBytes32Config(errors: string[], path: string, value: unknown): void {
+  if (!isConfiguredValue(value) || !/^0x[\dA-Fa-f]{64}$/.test(String(value))) {
+    pushConfigValidationError(errors, path, 'must be a 32-byte 0x-prefixed hex string')
+  }
+}
+
+function validateOptionalJsonConfig(errors: string[], path: string, value: string | undefined): void {
+  if (value === undefined) return
+  if (value.trim() === '') {
+    pushConfigValidationError(errors, path, 'must be valid JSON when set')
+    return
+  }
+
+  try {
+    JSON.parse(value.trim())
+  } catch {
+    pushConfigValidationError(errors, path, 'must be valid JSON')
+  }
+}
+
+function validateOptionalIntegerConfig(
+  errors: string[],
+  path: string,
+  value: unknown,
+  minimum: number,
+  description: string
+): void {
+  if (value === undefined || value === null) return
+  if (String(value).trim() === '') {
+    pushConfigValidationError(errors, path, `must be ${description}`)
+    return
+  }
+
+  const parsedValue = typeof value === 'number' ? value : Number(value)
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < minimum) {
+    pushConfigValidationError(errors, path, `must be ${description}`)
+  }
+}
+
+function validateRequiredIntegerConfig(
+  errors: string[],
+  path: string,
+  value: unknown,
+  minimum: number,
+  description: string
+): void {
+  if (!isConfiguredValue(value)) {
+    pushConfigValidationError(errors, path, `must be ${description}`)
+    return
+  }
+
+  validateOptionalIntegerConfig(errors, path, value, minimum, description)
+}
+
+function validateOptionalNonEmptyStringConfig(errors: string[], path: string, value: unknown): void {
+  if (value === undefined || value === null) return
+  if (String(value).trim() === '') {
+    pushConfigValidationError(errors, path, 'must not be empty')
+  }
+}
+
+export function validateDogeConfigEthereumDaForPrep(ethereumDa: DogeConfig['ethereumDa'] | undefined): void {
+  const errors: string[] = []
+  const batch = ethereumDa?.batch
+  const cutover = batch?.cutover
+  const hasCutover = cutover !== undefined
+  const hasL2StartBlockNumber = isConfiguredValue(ethereumDa?.l2StartBlockNumber)
+
+  validateOptionalIntegerConfig(errors, 'ethereumDa.l2StartBlockNumber', ethereumDa?.l2StartBlockNumber, 0, 'a non-negative integer')
+  if (hasCutover && !hasL2StartBlockNumber) {
+    pushConfigValidationError(errors, 'ethereumDa.l2StartBlockNumber', 'must be set when ethereumDa.batch.cutover is set')
+  }
+
+  if (!hasCutover && hasL2StartBlockNumber) {
+    pushConfigValidationError(errors, 'ethereumDa.batch.cutover', 'must be set when ethereumDa.l2StartBlockNumber is set')
+  }
+
+  if (batch) {
+    if (batch.compression !== undefined && !['auto', 'none'].includes(String(batch.compression))) {
+      pushConfigValidationError(errors, 'ethereumDa.batch.compression', 'must be auto or none')
+    }
+
+    validateOptionalBytes32Config(errors, 'ethereumDa.batch.genesisBatchHash', batch.genesisBatchHash)
+    validateOptionalBytes32Config(errors, 'ethereumDa.batch.genesisRelayedDepositQueueHash', batch.genesisRelayedDepositQueueHash)
+    validateOptionalBytes32Config(errors, 'ethereumDa.batch.genesisStateRoot', batch.genesisStateRoot)
+    validateOptionalBytes32Config(errors, 'ethereumDa.batch.genesisWithdrawRoot', batch.genesisWithdrawRoot)
+    validateOptionalJsonConfig(errors, 'ethereumDa.batch.initialBatchSidecarJson', batch.initialBatchSidecarJson)
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.genesisNextRelayedDepositIndex', batch.genesisNextRelayedDepositIndex, 0, 'a non-negative integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.genesisNextWithdrawIndex', batch.genesisNextWithdrawIndex, 0, 'a non-negative integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.maxBlocksPerChunk', batch.maxBlocksPerChunk, 1, 'a positive integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.maxChunksPerBatch', batch.maxChunksPerBatch, 1, 'a positive integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.maxL2GasPerChunk', batch.maxL2GasPerChunk, 1, 'a positive integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.maxUncompressedBatchBytesSize', batch.maxUncompressedBatchBytesSize, 1, 'a positive integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.batch.minCodecVersion', batch.minCodecVersion, 0, 'a non-negative integer')
+
+    if (cutover) {
+      validateRequiredIntegerConfig(errors, 'ethereumDa.batch.cutover.lastBatchIndex', cutover.lastBatchIndex, 0, 'a non-negative integer')
+      validateRequiredIntegerConfig(errors, 'ethereumDa.batch.cutover.nextRelayedDepositIndex', cutover.nextRelayedDepositIndex, 0, 'a non-negative integer')
+      validateRequiredIntegerConfig(errors, 'ethereumDa.batch.cutover.nextWithdrawIndex', cutover.nextWithdrawIndex, 0, 'a non-negative integer')
+      validateRequiredBytes32Config(errors, 'ethereumDa.batch.cutover.lastBatchHash', cutover.lastBatchHash)
+      validateRequiredBytes32Config(errors, 'ethereumDa.batch.cutover.relayedDepositQueueHash', cutover.relayedDepositQueueHash)
+      validateRequiredBytes32Config(errors, 'ethereumDa.batch.cutover.stateRoot', cutover.stateRoot)
+      validateRequiredBytes32Config(errors, 'ethereumDa.batch.cutover.withdrawRoot', cutover.withdrawRoot)
+    }
+  }
+
+  const publish = ethereumDa?.publish
+  if (publish) {
+    validateOptionalNonEmptyStringConfig(errors, 'ethereumDa.publish.budgetWindow', publish.budgetWindow)
+    validateOptionalIntegerConfig(errors, 'ethereumDa.publish.highBacklogThreshold', publish.highBacklogThreshold, 1, 'a positive integer')
+    validateOptionalNonEmptyStringConfig(errors, 'ethereumDa.publish.maxBatchWait', publish.maxBatchWait)
+    validateOptionalIntegerConfig(errors, 'ethereumDa.publish.maxBlobsPerTx', publish.maxBlobsPerTx, 1, 'a positive integer')
+    validateOptionalNonEmptyStringConfig(errors, 'ethereumDa.publish.maxLivenessDelay', publish.maxLivenessDelay)
+    validateOptionalIntegerConfig(errors, 'ethereumDa.publish.maxPendingBlobTxs', publish.maxPendingBlobTxs, 1, 'a positive integer')
+    validateOptionalIntegerConfig(errors, 'ethereumDa.publish.targetBlobsPerTx', publish.targetBlobsPerTx, 1, 'a positive integer')
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid doge-config Ethereum DA config:\n- ${errors.join('\n- ')}`)
+  }
 }
 
 export function buildL1InterfaceBlobSourcePrepEnv(input: {
@@ -1466,10 +1750,14 @@ export default class SetupPrepCharts extends Command {
           "DOGEOS_L1_INTERFACE_ETHEREUM_DA__L2_CHAIN_ID": String(this.getConfigValue("general.CHAIN_ID_L2")),
           "DOGEOS_L1_INTERFACE_INITIAL_SYSTEM_SIGNER": this.getConfigValue("sequencer.L2GETH_SIGNER_ADDRESS"),
           "DOGEOS_L1_INTERFACE_L1_BASE_FEE_PER_GAS": this.getConfigValue("genesis.BASE_FEE_PER_GAS").toString(),
+          "DOGEOS_L1_INTERFACE_L1_GAS_LIMIT": "30000000",
           "DOGEOS_L1_INTERFACE_L1_GENESIS_BLOCK": String(Math.max(0, l1GenesisBlock)),
           "DOGEOS_L1_INTERFACE_L2_MESSENGER_ADDRESS": this.getConfigValue("contractsFile.L2_DOGEOS_MESSENGER_PROXY_ADDR"),
           "DOGEOS_L1_INTERFACE_L2_MOAT_CONTRACT_ADDRESS": this.getConfigValue("contractsFile.L2_MOAT_PROXY_ADDR"),
           "DOGEOS_L1_INTERFACE_NETWORK_STR": this.withdrawalProcessorConfig.network_str,
+          "DOGEOS_L1_INTERFACE_REPLAY_READ__L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT": this.dogeConfig.defaults?.l2BootstrapNextStartingBlockHeight,
+          "DOGEOS_L1_INTERFACE_REPLAY_READ__MAINTAINER_ENABLED": "true",
+          "DOGEOS_L1_INTERFACE_REPLAY_READ__REQUIRE_FULL_VALIDATION": "false",
           "DOGEOS_L1_INTERFACE_SCROLL_CHAIN_ADDRESS": this.getConfigValue("contractsFile.L1_SCROLL_CHAIN_PROXY_ADDR"),
           // "DOGEOS_L1_INTERFACE_SCROLL_MESSENGER_ADDRESS": this.getConfigValue("contractsFile.L1_SCROLL_MESSENGER_PROXY_ADDR")
         }
@@ -1520,11 +1808,15 @@ export default class SetupPrepCharts extends Command {
         const s3ArchiveEnabled = truthyConfigValue(s3Archive?.enabled)
         const todoMappings: Record<string, any> = {
           "DOGEOS_WITHDRAWAL_BRIDGE_ADDRESS": this.withdrawalProcessorConfig.bridge_address,
-          // "DOGEOS_WITHDRAWAL_DATABASE_URL": "sqlite:///app/data/withdrawal_processor.db",
+          "DOGEOS_WITHDRAWAL_CLEANUP_TIMEOUT_SECS": "3600",
+          "DOGEOS_WITHDRAWAL_DATABASE_URL": "sqlite:///app/data/withdrawal_processor.sqlite",
+          "DOGEOS_WITHDRAWAL_DEBUG_SKIP_TSO_POLLING": "false",
+          "DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__POLL_INTERVAL_MS": "1000",
           "DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT": String(Math.max(0, dogecoinIndexerStartHeight)),
           "DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL": dogecoinInternalUrl,
           "DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__MESSAGE_QUEUE_ADDRESS": this.getConfigValue("contractsFile.L2_MESSAGE_QUEUE_ADDR"),
           "DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__MESSENGER_ADDRESS": this.getConfigValue("contractsFile.L2_DOGEOS_MESSENGER_PROXY_ADDR"),
+          "DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__POLL_INTERVAL_MS": "1000",
           "DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__RPC_URL": this.getConfigValue("general.L2_RPC_ENDPOINT"),
           "DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__START_BLOCK": "0",
           "DOGEOS_WITHDRAWAL_ETHEREUM_DA__ETH_CHAIN_ID": String(this.getConfigValue("ethereumDa.chainId")),
@@ -1540,8 +1832,39 @@ export default class SetupPrepCharts extends Command {
           "DOGEOS_WITHDRAWAL_GENESIS_SEQUENCER_TXID": this.withdrawalProcessorConfig.genesis_sequencer_txid,
           "DOGEOS_WITHDRAWAL_GENESIS_SEQUENCER_VOUT": this.withdrawalProcessorConfig.genesis_sequencer_vout,
           "DOGEOS_WITHDRAWAL_INITIAL_BRIDGE_REDEEM_SCRIPT_HEX": this.bridgeConfig.redeem_script_hex,
+          "DOGEOS_WITHDRAWAL_L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT": this.dogeConfig.defaults?.l2BootstrapNextStartingBlockHeight,
+          "DOGEOS_WITHDRAWAL_LEAF_VERIFICATION_REQUIRED": "false",
+          "DOGEOS_WITHDRAWAL_MAX_DEPOSITS_PER_ADVANCE_L1": "32",
+          "DOGEOS_WITHDRAWAL_MAX_WITHDRAWAL_OUTPUTS_PER_TX": "256",
           "DOGEOS_WITHDRAWAL_NETWORK_STR": this.withdrawalProcessorConfig.network_str,
-          "DOGEOS_WITHDRAWAL_TSO_URL": "http://tso-service:3000"
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__ENABLED": "false",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__LEASE_OWNER": "wp-local",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__LEASE_TTL_MS": "30000",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__MAX_ITEMS_PER_TICK": "1",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__POLL_INTERVAL_MS": "1000",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__RETRY_BASE_MS": "5000",
+          "DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__RETRY_CAP_MS": "300000",
+          "DOGEOS_WITHDRAWAL_PROOF_TASK_POLICY__SKIP_BRIDGE_STATE_PROOFS": "true",
+          "DOGEOS_WITHDRAWAL_PROOF_TASK_POLICY__SKIP_SCROLL_EXECUTION_PROOFS": "true",
+          "DOGEOS_WITHDRAWAL_REQUIRE_CHANGE_TRACKING": "false",
+          "DOGEOS_WITHDRAWAL_STRICT_L1_VALIDATION": "false",
+          "DOGEOS_WITHDRAWAL_STRICT_L2_VALIDATION": "false",
+          "DOGEOS_WITHDRAWAL_TSO_TIMEOUT_MINUTES": "30",
+          "DOGEOS_WITHDRAWAL_TSO_URL": "http://tso-service:3000",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__ALLOW_INFLIGHT_BRIDGE_OUTPUTS": "true",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_MIN_CONFIRMATIONS": "10",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__BALANCE_BAND_RATIO": "0.10",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__FLOOR_ABSOLUTE_SATS": "1000000",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__MAX_BALANCE_ADDITIONS": "3",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__SWEEP_FLOOR_RATIO": "0.5",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__TARGET_ACTIVE_UTXOS": "100",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__TARGET_SIZE_RATIO": "1.0",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__DUST_FLOOR_SATS": "1000000",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__MAX_INPUTS": "60",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__STRATEGY": "band",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__HIGH_THRESH_SATS": "10000000000",
+          "DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__PREFER_INFLIGHT_BRIDGE_OUTPUTS": "false",
+          "DOGEOS_WITHDRAWAL_WF_WITHDRAWAL_PARITY_V1": "true",
         }
 
         const ethereumDaEmbeddedIndexerStartBlock = this.dogeConfig.defaults?.ethereumDaEmbeddedIndexerStartBlock
@@ -1555,6 +1878,7 @@ export default class SetupPrepCharts extends Command {
         }
 
         const blobSourceChanges = removeEnvArrayKeys(productionYaml, [
+          'DOGEOS_WITHDRAWAL_BRIDGE_SCRIPT_HEX',
           'DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__KIND',
         ])
         if (blobSourceChanges.length > 0) {
@@ -1567,8 +1891,13 @@ export default class SetupPrepCharts extends Command {
 
           const envVar = productionYaml.env.find((item: any) => item.name === envKey);
           if (envVar) {
-            if (envVar.value !== newVal) {
-              const oldValue = envVar.value;
+            if (envVar.value !== newVal || envVar.valueFrom) {
+              const oldValue = envVar.value ?? JSON.stringify(envVar.valueFrom ?? 'undefined');
+              if (envKey === 'DOGEOS_WITHDRAWAL_DATABASE_URL' && envVar.valueFrom) {
+                this.jsonCtx.addWarning('withdrawal-processor: replacing secret-backed DOGEOS_WITHDRAWAL_DATABASE_URL with sqlite:///app/data/withdrawal_processor.sqlite for local chart storage')
+              }
+
+              delete envVar.valueFrom;
               envVar.value = newVal;
               updated = true;
               changes.push({ key: `env.${envKey}`, newValue: newVal, oldValue });
@@ -1616,25 +1945,30 @@ export default class SetupPrepCharts extends Command {
         - name: "DOGEOS_CUBESIGNER_SIGNER_NETWORK"
           value: "testnet"
         */
-        const envVarName = 'DOGEOS_CUBESIGNER_SIGNER_NETWORK';
-        const configValue = this.dogeConfig.network;
+        const todoMappings = {
+          CS_SESSIONS_DIR: '/app/.sessions',
+          CUBESIGNER_MAX_PSBT_BASE64_LEN: '130048',
+          DOGEOS_CUBESIGNER_SIGNER_LOG_LEVEL: 'info',
+          DOGEOS_CUBESIGNER_SIGNER_NETWORK: this.dogeConfig.network,
+          DOGEOS_CUBESIGNER_SIGNER_POLL_INTERVAL: '500',
+          DOGEOS_CUBESIGNER_SIGNER_SESSION_KEEP_ALIVE_INTERVAL: '3600000',
+          NETWORK: this.dogeConfig.network,
+        }
 
-        // Find existing environment variable
-        const envVar = productionYaml.env.find((item: any) => item.name === envVarName);
-
-        if (envVar) {
-          // Update existing value
-          if (envVar.value !== configValue) {
-            const oldValue = envVar.value;
-            envVar.value = configValue;
+        for (const [envKey, newValue] of Object.entries(todoMappings)) {
+          const envVar = productionYaml.env.find((item: any) => item.name === envKey);
+          if (envVar) {
+            if (envVar.value !== newValue) {
+              const oldValue = envVar.value;
+              envVar.value = newValue;
+              updated = true;
+              changes.push({ key: `env.${envKey}`, newValue, oldValue });
+            }
+          } else {
+            productionYaml.env.push({ name: envKey, value: newValue });
             updated = true;
-            changes.push({ key: `env.${envVarName}`, newValue: configValue, oldValue });
+            changes.push({ key: `env.${envKey}`, newValue, oldValue: 'undefined' });
           }
-        } else {
-          // Add new environment variable
-          productionYaml.env.push({ name: envVarName, value: configValue });
-          updated = true;
-          changes.push({ key: `env.${envVarName}`, newValue: configValue, oldValue: 'undefined' });
         }
       }
       else if (chartName === "eth-da-submitter") {
@@ -1642,17 +1976,27 @@ export default class SetupPrepCharts extends Command {
           this.error(`${chartName}: configMaps.env.data not found in config`);
         }
 
+        try {
+          validateDogeConfigEthereumDaForPrep(this.dogeConfig.ethereumDa)
+        } catch (error: any) {
+          this.error(error.message)
+        }
+
         const s3Archive = this.dogeConfig.ethereumDa?.blobArchive?.s3
         const todoMappings = buildEthDaSubmitterPrepEnv({
+          batch: this.dogeConfig.ethereumDa?.batch,
           ethereumChainId: this.getConfigValue("ethereumDa.chainId"),
           ethereumRpcUrl: this.getConfigValue("ethereumDa.submitterRpcUrl"),
           l2ChainId: this.getConfigValue("general.CHAIN_ID_L2"),
           l2RpcUrl: this.getConfigValue("general.L2_RPC_ENDPOINT"),
+          l2StartBlockNumber: this.dogeConfig.ethereumDa?.l2StartBlockNumber,
+          publish: this.dogeConfig.ethereumDa?.publish,
           s3Bucket: s3Archive?.bucket,
           s3Enabled: s3Archive?.enabled,
           s3EndpointUrl: s3Archive?.endpointUrl,
           s3ForcePathStyle: s3Archive?.forcePathStyle,
           s3InitialBackoffMs: s3Archive?.initialBackoffMs,
+          s3KeyPrefix: s3Archive?.keyPrefix,
           s3MaxBackoffMs: s3Archive?.maxBackoffMs,
           s3MaxRetries: s3Archive?.maxRetries,
           s3PollIntervalMs: s3Archive?.pollIntervalMs,
@@ -1680,6 +2024,15 @@ export default class SetupPrepCharts extends Command {
             updated = true;
             changes.push({ key: `configMaps.env.data.${envKey}`, newValue: String(newValue), oldValue: String(oldValue || 'undefined') });
           }
+        }
+
+        const initialBatchChanges = applyEthDaSubmitterInitialBatchSidecar(
+          productionYaml,
+          this.dogeConfig.ethereumDa?.batch?.initialBatchSidecarJson
+        )
+        if (initialBatchChanges.length > 0) {
+          changes.push(...initialBatchChanges)
+          updated = true
         }
 
         if (signerConfig?.backend === 'aws_kms') {
@@ -1723,7 +2076,10 @@ export default class SetupPrepCharts extends Command {
         }
 
         const todoMappings = {
-          "DOGE_NETWORK": this.dogeConfig.network
+          "DOGE_NETWORK": this.dogeConfig.network,
+          "TIMEOUT_CHECK_INTERVAL_SECONDS": "60",
+          "TSO_CORRECTNESS_MAX_PSBT_BASE64_LEN": "130048",
+          "TSO_CUBESIGNER_MAX_PSBT_BASE64_LEN": "130048",
         }
 
         for (const [envKey, newValue] of Object.entries(todoMappings)) {

--- a/src/types/deployment-spec.ts
+++ b/src/types/deployment-spec.ts
@@ -332,12 +332,22 @@ export interface EthereumDaConfig {
   /** Genesis frontier used by eth_da_submitter before the first published batch. */
   batch?: {
     compression?: 'auto' | 'none'
+    cutover?: {
+      lastBatchHash: string
+      lastBatchIndex: number
+      nextRelayedDepositIndex: number
+      nextWithdrawIndex: number
+      relayedDepositQueueHash: string
+      stateRoot: string
+      withdrawRoot: string
+    }
     genesisBatchHash?: string
     genesisNextRelayedDepositIndex?: number
     genesisNextWithdrawIndex?: number
     genesisRelayedDepositQueueHash?: string
     genesisStateRoot?: string
     genesisWithdrawRoot?: string
+    initialBatchSidecarJson?: string
     maxBlocksPerChunk?: number
     maxChunksPerBatch?: number
     maxL2GasPerChunk?: number
@@ -375,6 +385,8 @@ export interface EthereumDaConfig {
   l2Confirmations?: number
   /** DogeOS L2 execution RPC. Defaults to the fixed internal L2 RPC endpoint. */
   l2RpcUrl?: string
+  /** First L2 block for Ethereum DA cutover/replay-aware services. */
+  l2StartBlockNumber?: number
   lifecycleDbPath?: string
   /** Fee policy for EIP-4844 submissions. */
   maxBlobBaseFeeWei?: string
@@ -384,6 +396,16 @@ export interface EthereumDaConfig {
   minFinality?: 'finalized' | 'pending' | 'safe'
 
   minPriorityFeeWei?: string
+  publish?: {
+    allowLivenessBudgetOverride?: boolean
+    budgetWindow?: string
+    highBacklogThreshold?: number
+    maxBatchWait?: string
+    maxBlobsPerTx?: number
+    maxLivenessDelay?: string
+    maxPendingBlobTxs?: number
+    targetBlobsPerTx?: number
+  }
   signer?: EthereumDaSignerConfig
   /** eth_da_submitter lifecycle/store settings. */
   submitterDbPath?: string
@@ -399,6 +421,7 @@ export interface EthereumDaS3ArchiveConfig {
   endpointUrl?: string
   forcePathStyle?: boolean
   initialBackoffMs?: number
+  keyPrefix?: string
   maxBackoffMs?: number
   maxRetries?: number
   pollIntervalMs?: number

--- a/src/types/doge-config.ts
+++ b/src/types/doge-config.ts
@@ -40,6 +40,7 @@ export interface DogeConfig {
     dogecoinIndexerStartHeight?: string
     ethereumDaEmbeddedIndexerStartBlock?: string
     l1GenesisBlock?: string
+    l2BootstrapNextStartingBlockHeight?: string
   }
   dogecoinClusterRpc?: {
     password?: string // for dogecoin that deploy on cluster
@@ -50,6 +51,30 @@ export interface DogeConfig {
     provider?: 'aws' | 'local'
   }
   ethereumDa?: {
+    batch?: {
+      compression?: 'auto' | 'none'
+      cutover?: {
+        lastBatchHash: string
+        lastBatchIndex: number | string
+        nextRelayedDepositIndex: number | string
+        nextWithdrawIndex: number | string
+        relayedDepositQueueHash: string
+        stateRoot: string
+        withdrawRoot: string
+      }
+      genesisBatchHash?: string
+      genesisNextRelayedDepositIndex?: number | string
+      genesisNextWithdrawIndex?: number | string
+      genesisRelayedDepositQueueHash?: string
+      genesisStateRoot?: string
+      genesisWithdrawRoot?: string
+      initialBatchSidecarJson?: string
+      maxBlocksPerChunk?: number | string
+      maxChunksPerBatch?: number | string
+      maxL2GasPerChunk?: number | string
+      maxUncompressedBatchBytesSize?: number | string
+      minCodecVersion?: number | string
+    }
     beaconRpcUrl?: string
     blobArchive?: {
       s3?: {
@@ -58,6 +83,7 @@ export interface DogeConfig {
         endpointUrl?: string
         forcePathStyle?: boolean | string
         initialBackoffMs?: number | string
+        keyPrefix?: string
         maxBackoffMs?: number | string
         maxRetries?: number | string
         pollIntervalMs?: number | string
@@ -70,7 +96,18 @@ export interface DogeConfig {
     }
     chain?: 'devnet' | 'mainnet' | 'sepolia'
     chainId?: string
+    l2StartBlockNumber?: number | string
     minFinality?: 'finalized' | 'safe'
+    publish?: {
+      allowLivenessBudgetOverride?: boolean | string
+      budgetWindow?: string
+      highBacklogThreshold?: number | string
+      maxBatchWait?: string
+      maxBlobsPerTx?: number | string
+      maxLivenessDelay?: string
+      maxPendingBlobTxs?: number | string
+      targetBlobsPerTx?: number | string
+    }
     signer?: {
       backend?: 'aws_kms' | 'local'
       expectedAddress?: string

--- a/src/utils/deployment-spec-generator.ts
+++ b/src/utils/deployment-spec-generator.ts
@@ -538,10 +538,58 @@ export function validateDeploymentSpec(rawSpec: DeploymentSpec): ValidationResul
     }
   }
 
+  const validateOptionalBytes32Hex = (path: string, value: string | undefined): void => {
+    if (value === undefined) return
+    if (!/^0x[\dA-Fa-f]{64}$/.test(value)) {
+      pushInvalidEthereumDaConfigError(path, `${path} must be a 32-byte 0x-prefixed hex string`)
+    }
+  }
+
+  const validateRequiredBytes32Hex = (path: string, value: string | undefined): void => {
+    if (!value || !/^0x[\dA-Fa-f]{64}$/.test(value)) {
+      pushInvalidEthereumDaConfigError(path, `${path} must be a 32-byte 0x-prefixed hex string`)
+    }
+  }
+
+  const validateOptionalJsonString = (path: string, value: string | undefined): void => {
+    if (value === undefined) return
+    const trimmed = value.trim()
+    if (trimmed === '') {
+      pushInvalidEthereumDaConfigError(path, `${path} must be valid JSON when set`)
+      return
+    }
+
+    try {
+      JSON.parse(trimmed)
+    } catch {
+      pushInvalidEthereumDaConfigError(path, `${path} must be valid JSON`)
+    }
+  }
+
+  const validateOptionalNonEmptyString = (path: string, value: string | undefined): void => {
+    if (value === undefined) return
+    if (value.trim() === '') {
+      pushInvalidEthereumDaConfigError(path, `${path} must not be empty`)
+    }
+  }
+
   const validateOptionalNonNegativeSafeInteger = (path: string, value: number | undefined): void => {
     if (value === undefined) return
     if (!Number.isSafeInteger(value) || value < 0) {
       pushInvalidEthereumDaConfigError(path, `${path} must be a non-negative integer`)
+    }
+  }
+
+  const validateRequiredNonNegativeSafeInteger = (path: string, value: number | undefined): void => {
+    if (value === undefined || !Number.isSafeInteger(value) || value < 0) {
+      pushInvalidEthereumDaConfigError(path, `${path} must be a non-negative integer`)
+    }
+  }
+
+  const validateOptionalPositiveSafeInteger = (path: string, value: number | undefined): void => {
+    if (value === undefined) return
+    if (!Number.isSafeInteger(value) || value < 1) {
+      pushInvalidEthereumDaConfigError(path, `${path} must be a positive integer`)
     }
   }
 
@@ -766,6 +814,59 @@ export function validateDeploymentSpec(rawSpec: DeploymentSpec): ValidationResul
   }
 
   validateOptionalNonNegativeSafeInteger('ethereumDa.inboxWorker.startBlock', spec.ethereumDa?.inboxWorker?.startBlock)
+  validateOptionalNonNegativeSafeInteger('ethereumDa.l2StartBlockNumber', spec.ethereumDa?.l2StartBlockNumber)
+
+  const ethereumDaBatch = spec.ethereumDa?.batch
+  const hasEthereumDaCutover = ethereumDaBatch?.cutover !== undefined
+  const hasEthereumDaL2StartBlockNumber = spec.ethereumDa?.l2StartBlockNumber !== undefined
+  if (hasEthereumDaCutover && !hasEthereumDaL2StartBlockNumber) {
+    pushInvalidEthereumDaConfigError('ethereumDa.l2StartBlockNumber', 'ethereumDa.l2StartBlockNumber must be set when ethereumDa.batch.cutover is set')
+  }
+
+  if (!hasEthereumDaCutover && hasEthereumDaL2StartBlockNumber) {
+    pushInvalidEthereumDaConfigError('ethereumDa.batch.cutover', 'ethereumDa.batch.cutover must be set when ethereumDa.l2StartBlockNumber is set')
+  }
+
+  if (ethereumDaBatch) {
+    if (ethereumDaBatch.compression !== undefined && !['auto', 'none'].includes(ethereumDaBatch.compression)) {
+      pushInvalidEthereumDaConfigError('ethereumDa.batch.compression', 'ethereumDa.batch.compression must be auto or none')
+    }
+
+    validateOptionalBytes32Hex('ethereumDa.batch.genesisBatchHash', ethereumDaBatch.genesisBatchHash)
+    validateOptionalBytes32Hex('ethereumDa.batch.genesisRelayedDepositQueueHash', ethereumDaBatch.genesisRelayedDepositQueueHash)
+    validateOptionalBytes32Hex('ethereumDa.batch.genesisStateRoot', ethereumDaBatch.genesisStateRoot)
+    validateOptionalBytes32Hex('ethereumDa.batch.genesisWithdrawRoot', ethereumDaBatch.genesisWithdrawRoot)
+    validateOptionalJsonString('ethereumDa.batch.initialBatchSidecarJson', ethereumDaBatch.initialBatchSidecarJson)
+    validateOptionalNonNegativeSafeInteger('ethereumDa.batch.genesisNextRelayedDepositIndex', ethereumDaBatch.genesisNextRelayedDepositIndex)
+    validateOptionalNonNegativeSafeInteger('ethereumDa.batch.genesisNextWithdrawIndex', ethereumDaBatch.genesisNextWithdrawIndex)
+    validateOptionalPositiveSafeInteger('ethereumDa.batch.maxBlocksPerChunk', ethereumDaBatch.maxBlocksPerChunk)
+    validateOptionalPositiveSafeInteger('ethereumDa.batch.maxChunksPerBatch', ethereumDaBatch.maxChunksPerBatch)
+    validateOptionalPositiveSafeInteger('ethereumDa.batch.maxL2GasPerChunk', ethereumDaBatch.maxL2GasPerChunk)
+    validateOptionalPositiveSafeInteger('ethereumDa.batch.maxUncompressedBatchBytesSize', ethereumDaBatch.maxUncompressedBatchBytesSize)
+    validateOptionalNonNegativeSafeInteger('ethereumDa.batch.minCodecVersion', ethereumDaBatch.minCodecVersion)
+
+    const { cutover } = ethereumDaBatch
+    if (cutover) {
+      validateRequiredNonNegativeSafeInteger('ethereumDa.batch.cutover.lastBatchIndex', cutover.lastBatchIndex)
+      validateRequiredNonNegativeSafeInteger('ethereumDa.batch.cutover.nextRelayedDepositIndex', cutover.nextRelayedDepositIndex)
+      validateRequiredNonNegativeSafeInteger('ethereumDa.batch.cutover.nextWithdrawIndex', cutover.nextWithdrawIndex)
+      validateRequiredBytes32Hex('ethereumDa.batch.cutover.lastBatchHash', cutover.lastBatchHash)
+      validateRequiredBytes32Hex('ethereumDa.batch.cutover.relayedDepositQueueHash', cutover.relayedDepositQueueHash)
+      validateRequiredBytes32Hex('ethereumDa.batch.cutover.stateRoot', cutover.stateRoot)
+      validateRequiredBytes32Hex('ethereumDa.batch.cutover.withdrawRoot', cutover.withdrawRoot)
+    }
+  }
+
+  const ethereumDaPublish = spec.ethereumDa?.publish
+  if (ethereumDaPublish) {
+    validateOptionalNonEmptyString('ethereumDa.publish.budgetWindow', ethereumDaPublish.budgetWindow)
+    validateOptionalPositiveSafeInteger('ethereumDa.publish.highBacklogThreshold', ethereumDaPublish.highBacklogThreshold)
+    validateOptionalNonEmptyString('ethereumDa.publish.maxBatchWait', ethereumDaPublish.maxBatchWait)
+    validateOptionalPositiveSafeInteger('ethereumDa.publish.maxBlobsPerTx', ethereumDaPublish.maxBlobsPerTx)
+    validateOptionalNonEmptyString('ethereumDa.publish.maxLivenessDelay', ethereumDaPublish.maxLivenessDelay)
+    validateOptionalPositiveSafeInteger('ethereumDa.publish.maxPendingBlobTxs', ethereumDaPublish.maxPendingBlobTxs)
+    validateOptionalPositiveSafeInteger('ethereumDa.publish.targetBlobsPerTx', ethereumDaPublish.targetBlobsPerTx)
+  }
 
   if (spec.dogecoin?.indexerStartHeight !== undefined) {
     if (!Number.isSafeInteger(spec.dogecoin.indexerStartHeight) || spec.dogecoin.indexerStartHeight < 0) {
@@ -1228,6 +1329,22 @@ export function generateDogeConfigToml(rawSpec: DeploymentSpec): string {
     submitterRpcUrl: spec.ethereumDa?.l1RpcUrl || ethereumDaDefaults.submitterRpcUrl,
   }
 
+  if (spec.ethereumDa?.l2StartBlockNumber !== undefined) {
+    config.ethereumDa.l2StartBlockNumber = spec.ethereumDa.l2StartBlockNumber
+  }
+
+  if (spec.ethereumDa?.batch) {
+    config.ethereumDa.batch = Object.fromEntries(
+      Object.entries(spec.ethereumDa.batch).filter(([, value]) => value !== undefined)
+    )
+  }
+
+  if (spec.ethereumDa?.publish) {
+    config.ethereumDa.publish = Object.fromEntries(
+      Object.entries(spec.ethereumDa.publish).filter(([, value]) => value !== undefined)
+    )
+  }
+
   const ethereumDaS3Archive = spec.ethereumDa?.blobArchive?.s3
   if (ethereumDaS3Archive) {
     config.ethereumDa.blobArchive = {
@@ -1251,6 +1368,14 @@ export function generateDogeConfigToml(rawSpec: DeploymentSpec): string {
   config.defaults = {
     dogecoinIndexerStartHeight: String(getDogecoinIndexerStartHeight(spec)),
     l1GenesisBlock: String(getL1GenesisBlock(spec)),
+  }
+
+  if (spec.ethereumDa?.inboxWorker?.startBlock !== undefined) {
+    config.defaults.ethereumDaEmbeddedIndexerStartBlock = String(spec.ethereumDa.inboxWorker.startBlock)
+  }
+
+  if (spec.ethereumDa?.l2StartBlockNumber !== undefined) {
+    config.defaults.l2BootstrapNextStartingBlockHeight = String(spec.ethereumDa.l2StartBlockNumber)
   }
 
   config.frontend = {

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -367,6 +367,7 @@ function buildEthereumDaS3BlobSourceEnv(prefix: string, spec: DeploymentSpec): R
     [`${prefix}__BLOB_SOURCE__AWS_S3__URL`]: s3.publicBaseUrl,
   }
 
+  addStringEnvIfDefined(env, `${prefix}__BLOB_SOURCE__AWS_S3__KEY_PREFIX`, s3.keyPrefix)
   addStringEnvIfDefined(env, `${prefix}__BLOB_SOURCE__AWS_S3__TIMEOUT_MS`, s3.timeoutMs)
   addStringEnvIfDefined(env, `${prefix}__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING`, s3.treatForbiddenAsMissing)
 

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -229,9 +229,112 @@ function getEthereumDaInboxWorkerStartBlock(spec: DeploymentSpec): number {
   return getEthereumDaConfig(spec).inboxWorker?.startBlock ?? 0
 }
 
+function getEthereumDaL2StartBlockNumber(spec: DeploymentSpec): number | undefined {
+  return getEthereumDaConfig(spec).l2StartBlockNumber
+}
+
 function addStringEnvIfDefined(target: Record<string, string>, key: string, value: unknown): void {
   if (value === undefined || value === null) return
   target[key] = String(value)
+}
+
+function normalizeInitialBatchSidecarJson(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  if (trimmed === '') return undefined
+  try {
+    JSON.parse(trimmed)
+  } catch {
+    throw new Error('ethereumDa.batch.initialBatchSidecarJson must be valid JSON')
+  }
+
+  return trimmed
+}
+
+function buildEthDaSubmitterBatchEnv(spec: DeploymentSpec): Record<string, string> {
+  const batch = getEthereumDaBatchConfig(spec)
+  const {cutover} = batch
+  const env: Record<string, string> = {
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__COMPRESSION: batch.compression ?? 'auto',
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_BATCH_HASH: batch.genesisBatchHash ?? cutover?.lastBatchHash ?? ZERO_HASH,
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_RELAYED_DEPOSIT_INDEX: String(batch.genesisNextRelayedDepositIndex ?? cutover?.nextRelayedDepositIndex ?? 0),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_WITHDRAW_INDEX: String(batch.genesisNextWithdrawIndex ?? cutover?.nextWithdrawIndex ?? 0),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_RELAYED_DEPOSIT_QUEUE_HASH: batch.genesisRelayedDepositQueueHash ?? cutover?.relayedDepositQueueHash ?? ZERO_HASH,
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_STATE_ROOT: batch.genesisStateRoot ?? cutover?.stateRoot ?? ZERO_HASH,
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_WITHDRAW_ROOT: batch.genesisWithdrawRoot ?? cutover?.withdrawRoot ?? ZERO_HASH,
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_BLOCKS_PER_CHUNK: String(batch.maxBlocksPerChunk ?? 128),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_CHUNKS_PER_BATCH: String(batch.maxChunksPerBatch ?? 1),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_L2_GAS_PER_CHUNK: String(batch.maxL2GasPerChunk ?? 6_000_000),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_UNCOMPRESSED_BATCH_BYTES_SIZE: String(batch.maxUncompressedBatchBytesSize ?? 131_072),
+    DOGEOS_ETH_DA_SUBMITTER_BATCH__MIN_CODEC_VERSION: String(batch.minCodecVersion ?? 10),
+  }
+
+  if (cutover) {
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_HASH = cutover.lastBatchHash
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_INDEX = String(cutover.lastBatchIndex)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__NEXT_RELAYED_DEPOSIT_INDEX = String(cutover.nextRelayedDepositIndex)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__NEXT_WITHDRAW_INDEX = String(cutover.nextWithdrawIndex)
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__RELAYED_DEPOSIT_QUEUE_HASH = cutover.relayedDepositQueueHash
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__STATE_ROOT = cutover.stateRoot
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__WITHDRAW_ROOT = cutover.withdrawRoot
+  }
+
+  const initialBatchSidecarJson = normalizeInitialBatchSidecarJson(batch.initialBatchSidecarJson)
+  if (initialBatchSidecarJson) {
+    env.DOGEOS_ETH_DA_SUBMITTER_BATCH__INITIAL_BATCH_SIDECAR_JSON = '/app/config/initial_batch.json'
+  }
+
+  return env
+}
+
+function buildEthDaSubmitterPublishEnv(spec: DeploymentSpec): Record<string, string> {
+  const {publish} = getEthereumDaConfig(spec)
+  if (!publish) return {}
+
+  const env: Record<string, string> = {}
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__ALLOW_LIVENESS_BUDGET_OVERRIDE', publish.allowLivenessBudgetOverride)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__BUDGET_WINDOW', publish.budgetWindow)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__HIGH_BACKLOG_THRESHOLD', publish.highBacklogThreshold)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_BATCH_WAIT', publish.maxBatchWait)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_BLOBS_PER_TX', publish.maxBlobsPerTx)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_LIVENESS_DELAY', publish.maxLivenessDelay)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_PENDING_BLOB_TXS', publish.maxPendingBlobTxs)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_PUBLISH__TARGET_BLOBS_PER_TX', publish.targetBlobsPerTx)
+
+  return env
+}
+
+function buildFeeOracleEthereumDaEnv(spec: DeploymentSpec): Record<string, string> {
+  return {
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__ADVANCE_L2__MAX_L2_PAYLOAD_BYTES_PER_ADVANCE_L2: '90000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__ADVANCE_L2__MAX_SOURCE_AGE_SECONDS: '300',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__CONTRACT_WRITE_MODE: 'dry_run',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__ETH_RPC_URL: getEthereumDaSubmitterRpcUrl(spec),
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__EXECUTION_GAS_FLOOR: '21000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__EXECUTION_GAS_SOURCE: 'conceptual_floor',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_LIMIT_SAFETY_MARGIN: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__FORMULA: 'galileo',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__PRECISION_DEC: '1000000000',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__SCALAR_POLICY: 'static_verified',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__MAX_BLOBS_PER_TX: '6',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRICES__MAX_QUOTE_AGE_SECONDS: '60',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRICES__MIN_SOURCE_QUORUM: '2',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__PRIORITY_FEE_SOURCE: 'configured_min',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__SAMPLE_INTERVAL_SECONDS: '30',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__SAMPLE_STALE_AFTER_SECONDS: '90',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__TARGET_BLOBS_PER_TX: '2',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ADVANCE_L2_STALE_FALLBACK: 'not_ready',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__FIRST_VALID_ORACLE_VALUES: 'update',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__FORCE_UPDATE_AFTER_SECONDS: '3600',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__MAX_ORACLE_VALUE_AGE_SECONDS: '1800',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ORACLE_VALUE_STAT: 'median',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__ORACLE_VALUE_WINDOW_SECONDS: '300',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__PRICE_UNAVAILABLE_FALLBACK: 'hold_last',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__RELATIVE_DELTA_THRESHOLD_PPM__BASE_FEE_PER_GAS: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__RELATIVE_DELTA_THRESHOLD_PPM__BLOB_BASE_FEE_PER_BLOB_GAS: '0',
+    DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__SUBMITTER_DEFERRED_FALLBACK: 'hold_last',
+  }
 }
 
 function buildEthDaSubmitterS3Env(spec: DeploymentSpec): Record<string, string> {
@@ -244,6 +347,7 @@ function buildEthDaSubmitterS3Env(spec: DeploymentSpec): Record<string, string> 
 
   addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__BUCKET', s3.bucket)
   addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__REGION', s3.region)
+  addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__KEY_PREFIX', s3.keyPrefix)
   addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__ENDPOINT_URL', s3.endpointUrl)
   addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__FORCE_PATH_STYLE', s3.forcePathStyle)
   addStringEnvIfDefined(env, 'DOGEOS_ETH_DA_SUBMITTER_S3__POLL_INTERVAL_MS', s3.pollIntervalMs)
@@ -606,6 +710,7 @@ function generateL2RpcValues(spec: DeploymentSpec): string {
 function generateL1InterfaceValues(spec: DeploymentSpec): string {
   const secretConfig = getSecretProviderConfig(spec)
   const dogecoinEndpoints = resolveDogecoinKubernetesEndpoints(spec.dogecoin)
+  const l2StartBlockNumber = getEthereumDaL2StartBlockNumber(spec)
 
   const image = resolveImage(spec, 'l1Interface', {
     pullPolicy: 'Always',
@@ -637,11 +742,17 @@ function generateL1InterfaceValues(spec: DeploymentSpec): string {
           DOGEOS_L1_INTERFACE_GENESIS_JSON_PATH: '/app/genesis/genesis.json',
           DOGEOS_L1_INTERFACE_HEALTH_LISTEN_ADDRESS: '0.0.0.0:9090',
           DOGEOS_L1_INTERFACE_L1_CHAIN_ID: String(spec.network.l1ChainId),
+          DOGEOS_L1_INTERFACE_L1_GAS_LIMIT: '30000000',
           DOGEOS_L1_INTERFACE_L1_GENESIS_BLOCK: String(getL1GenesisBlock(spec)),
           DOGEOS_L1_INTERFACE_NETWORK_STR: spec.dogecoin.network,
           DOGEOS_L1_INTERFACE_REPLAY_READ__ENABLED: 'true',
+          DOGEOS_L1_INTERFACE_REPLAY_READ__MAINTAINER_ENABLED: 'true',
           DOGEOS_L1_INTERFACE_REPLAY_READ__PROTOCOL_CONTEXT_JSON: '/app/protocol_context.json',
-          DOGEOS_L1_INTERFACE_REPLAY_READ__SQLITE_PATH: '/data/replay.sqlite'
+          DOGEOS_L1_INTERFACE_REPLAY_READ__REQUIRE_FULL_VALIDATION: 'false',
+          DOGEOS_L1_INTERFACE_REPLAY_READ__SQLITE_PATH: '/data/replay.sqlite',
+          ...(l2StartBlockNumber === undefined ? {} : {
+            DOGEOS_L1_INTERFACE_REPLAY_READ__L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT: String(l2StartBlockNumber),
+          })
         },
         enabled: true
       }
@@ -654,6 +765,30 @@ function generateL1InterfaceValues(spec: DeploymentSpec): string {
       { configMapRef: { name: 'l1-interface-env' } }
     ],
     image,
+    persistence: {
+      data: {
+        enabled: true,
+        mountPath: '/data',
+        name: 'l1-interface-data-pvc',
+        retain: true,
+        size: '100Gi',
+        type: 'pvc',
+      },
+      genesis: {
+        enabled: true,
+        mountPath: '/app/genesis/genesis.json',
+        name: 'genesis-config',
+        readOnly: true,
+        type: 'configMap',
+      },
+      'protocol-context': {
+        enabled: true,
+        mountPath: '/app/protocol_context.json',
+        name: 'protocol-context-config',
+        readOnly: true,
+        type: 'configMap',
+      },
+    },
     resources: {
       limits: { cpu: '1000m', memory: '1Gi' },
       requests: { cpu: '100m', memory: '256Mi' }
@@ -742,6 +877,7 @@ function generateEthDaSubmitterValues(spec: DeploymentSpec): string {
   const batch = getEthereumDaBatchConfig(spec)
   const { signer } = ethereumDa
   const isAwsKmsSigner = signer?.backend === 'aws_kms'
+  const l2StartBlockNumber = getEthereumDaL2StartBlockNumber(spec)
 
   const image = resolveImage(spec, 'ethDaSubmitter', {
     pullPolicy: 'IfNotPresent',
@@ -753,22 +889,16 @@ function generateEthDaSubmitterValues(spec: DeploymentSpec): string {
     configMaps: {
       env: {
         data: {
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__COMPRESSION: batch.compression || 'auto',
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_BATCH_HASH: batch.genesisBatchHash || ZERO_HASH,
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_RELAYED_DEPOSIT_INDEX: String(batch.genesisNextRelayedDepositIndex ?? 0),
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_NEXT_WITHDRAW_INDEX: String(batch.genesisNextWithdrawIndex ?? 0),
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_STATE_ROOT: batch.genesisStateRoot || ZERO_HASH,
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_BLOCKS_PER_CHUNK: String(batch.maxBlocksPerChunk ?? 128),
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_CHUNKS_PER_BATCH: String(batch.maxChunksPerBatch ?? 1),
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_UNCOMPRESSED_BATCH_BYTES_SIZE: String(batch.maxUncompressedBatchBytesSize ?? 131_072),
-          DOGEOS_ETH_DA_SUBMITTER_BATCH__MIN_CODEC_VERSION: String(batch.minCodecVersion ?? 10),
+          ...buildEthDaSubmitterBatchEnv(spec),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__CONFIRMATION_DEPTH: String(ethereumDa.confirmationDepth ?? 1),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__CONFIRMER_POLL_INTERVAL_MS: String(ethereumDa.confirmerPollIntervalMs ?? 12_000),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__ETH_CHAIN_ID: String(getEthereumDaChainId(spec)),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__FINALIZATION_DEPTH: String(ethereumDa.finalizationDepth ?? 64),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__L2_CHAIN_ID: String(spec.network.l2ChainId),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__MAX_BLOB_BASE_FEE_WEI: ethereumDa.maxBlobBaseFeeWei || '50000000000',
-          DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__MAX_FEE_PER_GAS_WEI: ethereumDa.maxFeePerGasWei || '',
+          ...(ethereumDa.maxFeePerGasWei ? {
+            DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__MAX_FEE_PER_GAS_WEI: ethereumDa.maxFeePerGasWei,
+          } : {}),
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__MIN_PRIORITY_FEE_WEI: ethereumDa.minPriorityFeeWei || '2000000000',
           DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__RPC_URL: getEthereumDaSubmitterRpcUrl(spec),
           ...(isAwsKmsSigner ? {
@@ -782,6 +912,10 @@ function generateEthDaSubmitterValues(spec: DeploymentSpec): string {
           DOGEOS_ETH_DA_SUBMITTER_L2__CONFIRMATIONS: String(ethereumDa.l2Confirmations ?? 0),
           DOGEOS_ETH_DA_SUBMITTER_L2__FETCH_LIMIT: String(ethereumDa.fetchLimit ?? 128),
           DOGEOS_ETH_DA_SUBMITTER_L2__RPC_URL: ethereumDa.l2RpcUrl || L2_RPC_ENDPOINT,
+          ...(l2StartBlockNumber === undefined ? {} : {
+            DOGEOS_ETH_DA_SUBMITTER_L2__START_BLOCK_NUMBER: String(l2StartBlockNumber),
+          }),
+          ...buildEthDaSubmitterPublishEnv(spec),
           ...buildEthDaSubmitterS3Env(spec),
           DOGEOS_ETH_DA_SUBMITTER_SERVICE__CYCLE_INTERVAL_MS: '1000',
           DOGEOS_ETH_DA_SUBMITTER_SERVICE__LISTEN_ADDRESS: '0.0.0.0',
@@ -821,6 +955,24 @@ function generateEthDaSubmitterValues(spec: DeploymentSpec): string {
       } : {},
       create: true,
       name: signer?.serviceAccountName || 'eth-da-submitter',
+    }
+  }
+
+  const initialBatchSidecarJson = normalizeInitialBatchSidecarJson(batch.initialBatchSidecarJson)
+  if (initialBatchSidecarJson) {
+    values.configMaps['initial-batch'] = {
+      data: {
+        'initial_batch.json': initialBatchSidecarJson,
+      },
+      enabled: true,
+    }
+    values.persistence['initial-batch'] = {
+      enabled: true,
+      items: [{ key: 'initial_batch.json', path: 'initial_batch.json' }],
+      mountPath: '/app/config',
+      name: '{{ include "scroll.common.lib.chart.names.fullname" . }}-initial-batch',
+      readOnly: true,
+      type: 'configMap',
     }
   }
 
@@ -927,6 +1079,9 @@ function generateTsoServiceValues(spec: DeploymentSpec): string {
       { name: 'PORT', value: '3000' },
       { name: 'DOGE_NETWORK', value: spec.dogecoin.network },
       { name: 'WITHDRAWAL_PROCESSOR_URL', value: 'http://withdrawal-processor:3000' },
+      { name: 'TIMEOUT_CHECK_INTERVAL_SECONDS', value: '60' },
+      { name: 'TSO_CORRECTNESS_MAX_PSBT_BASE64_LEN', value: '130048' },
+      { name: 'TSO_CUBESIGNER_MAX_PSBT_BASE64_LEN', value: '130048' },
       { name: 'RUST_LOG', value: 'debug' }
     ],
     image,
@@ -962,6 +1117,7 @@ function generateWithdrawalProcessorValues(spec: DeploymentSpec): string {
   const secretConfig = getSecretProviderConfig(spec)
   const dogecoinEndpoints = resolveDogecoinKubernetesEndpoints(spec.dogecoin)
   const ethereumDaSigner = getEthereumDaConfig(spec).signer
+  const l2StartBlockNumber = getEthereumDaL2StartBlockNumber(spec)
 
   const image = resolveImage(spec, 'withdrawalProcessor', {
     pullPolicy: 'Always',
@@ -972,31 +1128,68 @@ function generateWithdrawalProcessorValues(spec: DeploymentSpec): string {
   const values: Record<string, any> = {
     env: [
       { name: 'DOGEOS_WITHDRAWAL_NETWORK_STR', value: spec.dogecoin.network },
-      { name: 'DOGEOS_WITHDRAWAL_DATABASE_URL', valueFrom: { secretKeyRef: { key: 'DOGEOS_WITHDRAWAL_DATABASE_URL', name: 'withdrawal-processor-secret-env' } } },
+      { name: 'DOGEOS_WITHDRAWAL_DATABASE_URL', value: 'sqlite:///app/data/withdrawal_processor.sqlite' },
       { name: 'DOGEOS_WITHDRAWAL_API_PORT', value: '3000' },
       { name: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_URL', value: dogecoinEndpoints.rpcUrl },
       { name: 'DOGEOS_WITHDRAWAL_TSO_URL', value: 'http://tso-service:3000' },
       { name: 'DOGEOS_WITHDRAWAL_BRIDGE_ADDRESS', value: '' },
-      { name: 'DOGEOS_WITHDRAWAL_BRIDGE_SCRIPT_HEX', value: '' },
-      { name: 'DOGEOS_WITHDRAWAL_MAX_WITHDRAWAL_OUTPUTS_PER_TX', value: '1024' },
+      { name: 'DOGEOS_WITHDRAWAL_INITIAL_BRIDGE_REDEEM_SCRIPT_HEX', value: '' },
+      { name: 'DOGEOS_WITHDRAWAL_GENESIS_SEQUENCER_TXID', value: '' },
+      { name: 'DOGEOS_WITHDRAWAL_GENESIS_SEQUENCER_VOUT', value: '0' },
+      { name: 'DOGEOS_WITHDRAWAL_MAX_WITHDRAWAL_OUTPUTS_PER_TX', value: '256' },
       { name: 'DOGEOS_WITHDRAWAL_FEE_RATE_SAT_PER_KVB', value: String(getBridgeFeeRateSatsPerKvb(spec)) },
       { name: 'DOGEOS_WITHDRAWAL_COORDINATOR_POLL_INTERVAL_SECS', value: '10' },
       { name: 'DOGEOS_WITHDRAWAL_DEBUG_SKIP_BROADCAST', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_DEBUG_SKIP_TSO_POLLING', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_TSO_TIMEOUT_MINUTES', value: '30' },
+      { name: 'DOGEOS_WITHDRAWAL_CLEANUP_TIMEOUT_SECS', value: '3600' },
       { name: 'DOGEOS_WITHDRAWAL_ROTATE_KEY_V2', value: 'true' },
       { name: 'DOGEOS_WITHDRAWAL_ADVANCE_L1_BUILDER_V2', value: 'true' },
       { name: 'DOGEOS_WITHDRAWAL_ADVANCE_L2_BUILDER_V2', value: 'true' },
+      { name: 'DOGEOS_WITHDRAWAL_WF_WITHDRAWAL_PARITY_V1', value: 'true' },
+      { name: 'DOGEOS_WITHDRAWAL_REQUIRE_CHANGE_TRACKING', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_STRICT_L2_VALIDATION', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_STRICT_L1_VALIDATION', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_LEAF_VERIFICATION_REQUIRED', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_MAX_DEPOSITS_PER_ADVANCE_L1', value: '32' },
       { name: 'DOGEOS_WITHDRAWAL_REPLAY_SQLITE_PATH', value: '/app/data/replay.sqlite' },
       { name: 'DOGEOS_WITHDRAWAL_PROTOCOL_CONTEXT_JSON', value: '/app/protocol_context.json' },
+      ...(l2StartBlockNumber === undefined ? [] : [{
+        name: 'DOGEOS_WITHDRAWAL_L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT',
+        value: String(l2StartBlockNumber),
+      }]),
       // Dogecoin Indexer
       { name: 'DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__START_HEIGHT', value: String(getDogecoinIndexerStartHeight(spec)) },
       { name: 'DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__CONFIRMATIONS', value: String(spec.bridge.confirmationsRequired) },
-      { name: 'DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__POLL_INTERVAL_MS', value: '60000' },
+      { name: 'DOGEOS_WITHDRAWAL_DOGECOIN_INDEXER__POLL_INTERVAL_MS', value: '1000' },
       // DogeOS Indexer
       { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__RPC_URL', value: L2_RPC_ENDPOINT },
       { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__START_BLOCK', value: '0' },
       { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__CONFIRMATIONS', value: '12' },
-      { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__POLL_INTERVAL_MS', value: '60000' },
+      { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__POLL_INTERVAL_MS', value: '1000' },
       { name: 'DOGEOS_WITHDRAWAL_DOGEOS_INDEXER__LOG_QUERY_BATCH_SIZE', value: '10000' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__HIGH_THRESH_SATS', value: '10000000000' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_MIN_CONFIRMATIONS', value: '10' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__ALLOW_INFLIGHT_BRIDGE_OUTPUTS', value: 'true' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__PREFER_INFLIGHT_BRIDGE_OUTPUTS', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__STRATEGY', value: 'band' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__MAX_INPUTS', value: '60' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__DUST_FLOOR_SATS', value: '1000000' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__TARGET_ACTIVE_UTXOS', value: '100' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__TARGET_SIZE_RATIO', value: '1.0' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__SWEEP_FLOOR_RATIO', value: '0.5' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__BALANCE_BAND_RATIO', value: '0.10' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__MAX_BALANCE_ADDITIONS', value: '3' },
+      { name: 'DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__BAND__FLOOR_ABSOLUTE_SATS', value: '1000000' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_TASK_POLICY__SKIP_SCROLL_EXECUTION_PROOFS', value: 'true' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_TASK_POLICY__SKIP_BRIDGE_STATE_PROOFS', value: 'true' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__ENABLED', value: 'false' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__LEASE_OWNER', value: 'wp-local' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__LEASE_TTL_MS', value: '30000' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__MAX_ITEMS_PER_TICK', value: '1' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__POLL_INTERVAL_MS', value: '1000' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__RETRY_BASE_MS', value: '5000' },
+      { name: 'DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__RETRY_CAP_MS', value: '300000' },
       // Ethereum DA resolver/indexer inputs for AdvanceL2 builder v2.
       { name: 'DOGEOS_WITHDRAWAL_ETHEREUM_DA__L1_RPC_URL', value: getEthereumDaSubmitterRpcUrl(spec) },
       { name: 'DOGEOS_WITHDRAWAL_ETHEREUM_DA__ETH_CHAIN_ID', value: String(getEthereumDaChainId(spec)) },
@@ -1029,6 +1222,23 @@ function generateWithdrawalProcessorValues(spec: DeploymentSpec): string {
       { secretRef: { name: 'withdrawal-processor-secret-env' } }
     ],
     image,
+    persistence: {
+      data: {
+        enabled: true,
+        mountPath: '/app/data',
+        name: 'withdrawal-processor-data-pvc',
+        retain: true,
+        size: '100Gi',
+        type: 'pvc',
+      },
+      'protocol-context': {
+        enabled: true,
+        mountPath: '/app/protocol_context.json',
+        name: 'protocol-context-config',
+        readOnly: true,
+        type: 'configMap',
+      },
+    },
     resources: {
       limits: { cpu: '1000m', memory: '2Gi' },
       requests: { cpu: '200m', memory: '512Mi' }
@@ -1039,9 +1249,10 @@ function generateWithdrawalProcessorValues(spec: DeploymentSpec): string {
     'withdrawal-processor-secret-env',
     secretConfig,
     [
-      { property: 'DOGEOS_WITHDRAWAL_DATABASE_URL', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_DATABASE_URL' },
       { property: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_USER', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_USER' },
-      { property: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS' }
+      { property: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS' },
+      { property: 'DOGEOS_WITHDRAWAL_FEE_SIGNER_KEY', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_FEE_SIGNER_KEY' },
+      { property: 'DOGEOS_WITHDRAWAL_SEQUENCER_SIGNER_KEY', remoteKey: 'withdrawal-processor-secret-env', secretKey: 'DOGEOS_WITHDRAWAL_SEQUENCER_SIGNER_KEY' },
     ]
   )
 
@@ -1066,14 +1277,19 @@ function generateCubesignerValues(spec: DeploymentSpec): string {
 
   const values: Record<string, any> = {
     env: [
+      { name: 'DOGEOS_CUBESIGNER_SIGNER_LOG_LEVEL', value: 'info' },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_PORT', value: '3000' },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_NETWORK', value: spec.dogecoin.network },
+      { name: 'NETWORK', value: spec.dogecoin.network },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_TSO_URL', value: 'http://tso-service:3000' },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_SIGNATURE_DELAY', value: '0' },
-      { name: 'DOGEOS_CUBESIGNER_SIGNER_POLL_INTERVAL', value: '5000' },
+      { name: 'DOGEOS_CUBESIGNER_SIGNER_POLL_INTERVAL', value: '500' },
+      { name: 'DOGEOS_CUBESIGNER_SIGNER_SESSION_KEEP_ALIVE_INTERVAL', value: '3600000' },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_CS_KEY_ID', valueFrom: { secretKeyRef: { key: 'DOGEOS_CUBESIGNER_SIGNER_CS_KEY_ID', name: 'cubesigner-signer-__INSTANCE_INDEX__-env' } } },
       { name: 'DOGEOS_CUBESIGNER_SIGNER_CS_SESSION_PATH', value: '/etc/cubesigner/session.json' },
-      { name: 'DOGEOS_CUBESIGNER_SIGNER_BODY_LIMIT', value: '5mb' }
+      { name: 'DOGEOS_CUBESIGNER_SIGNER_BODY_LIMIT', value: '5mb' },
+      { name: 'CUBESIGNER_MAX_PSBT_BASE64_LEN', value: '130048' },
+      { name: 'CS_SESSIONS_DIR', value: '/app/.sessions' }
     ],
     global: {
       fullnameOverride: 'cubesigner-signer-__INSTANCE_INDEX__'
@@ -1282,9 +1498,7 @@ function generateFeeOracleValues(spec: DeploymentSpec): string {
         data: {
           DOGEOS_FEE_ORACLE_DATABASE__CONNECTION_POOL_SIZE: '10',
           DOGEOS_FEE_ORACLE_DATABASE__SQLITE_PATH: '/data/fee_oracle.db',
-          DOGEOS_FEE_ORACLE_ETHEREUM_DA__CONTRACT_WRITE_MODE: 'dry_run',
-          DOGEOS_FEE_ORACLE_ETHEREUM_DA__ETH_RPC_URL: getEthereumDaSubmitterRpcUrl(spec),
-          DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI: '"0"',
+          ...buildFeeOracleEthereumDaEnv(spec),
           DOGEOS_FEE_ORACLE_L2__CHAIN_ID: String(spec.network.l2ChainId),
           DOGEOS_FEE_ORACLE_L2__CONFIRMATIONS: '3',
           DOGEOS_FEE_ORACLE_L2__GAS_ORACLE_CONTRACT: spec.contracts.overrides?.l1GasPriceOracle || '<TODO>',

--- a/test/commands/setup/prep-charts.test.ts
+++ b/test/commands/setup/prep-charts.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 
 import {
   applyConfigMapEnvValues,
+  applyEthDaSubmitterInitialBatchSidecar,
   applyFeeOracleCurrentEnv,
   buildEthDaSubmitterPrepEnv,
   buildFeeOraclePrepEnv,
@@ -11,7 +12,18 @@ import {
   removeEnvArrayKeys,
   scrubFeeOracleLegacyValues,
   shouldSkipL2ContractDeploymentBlockUpdate,
+  validateDogeConfigEthereumDaForPrep,
 } from '../../../src/commands/setup/prep-charts.js'
+
+const VALID_PREP_CUTOVER = {
+  lastBatchHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  lastBatchIndex: 4379,
+  nextRelayedDepositIndex: 24_922,
+  nextWithdrawIndex: 13_047,
+  relayedDepositQueueHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+  stateRoot: '0x3333333333333333333333333333333333333333333333333333333333333333',
+  withdrawRoot: '0x4444444444444444444444444444444444444444444444444444444444444444',
+}
 
 describe('setup prep-charts L2 contract deployment block updates', () => {
   it('does not skip L2GETH_L1_CONTRACT_DEPLOYMENT_BLOCK by default', () => {
@@ -103,7 +115,9 @@ describe('setup prep-charts fee-oracle updates', () => {
     expect(values.configMaps.env.data).not.to.have.property('DOGEOS_FEE_ORACLE_PRICE_ORACLE__UPDATE_ON_EACH_CYCLE')
     expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__CONTRACT_WRITE_MODE).to.equal('dry_run')
     expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__ETH_RPC_URL).to.equal('https://eth.example')
-    expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI).to.equal('"0"')
+    expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI).to.equal('0')
+    expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__FORMULA).to.equal('galileo')
+    expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__PRICE_UNAVAILABLE_FALLBACK).to.equal('hold_last')
     expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_L2__RPC_URL).to.equal('http://l2-rpc:8545')
     expect(values.configMaps.env.data.DOGEOS_FEE_ORACLE_WALLET__PRIVATE_KEY_ENV).to.equal('DOGEOS_FEE_ORACLE_PRIVATE_KEY')
     expect(values.env).to.deep.equal([{ name: 'RUST_LOG', value: 'info' }])
@@ -144,6 +158,7 @@ describe('setup prep-charts eth-da-submitter updates', () => {
       s3Bucket: 'dogeos-da',
       s3Enabled: true,
       s3ForcePathStyle: false,
+      s3KeyPrefix: 'devnet/eth-da/blobs/v1',
       s3MaxRetries: 5,
       s3Region: 'us-east-1',
     })
@@ -151,8 +166,139 @@ describe('setup prep-charts eth-da-submitter updates', () => {
     expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__ENABLED).to.equal('true')
     expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__BUCKET).to.equal('dogeos-da')
     expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__REGION).to.equal('us-east-1')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1')
     expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__FORCE_PATH_STYLE).to.equal('false')
     expect(env.DOGEOS_ETH_DA_SUBMITTER_S3__MAX_RETRIES).to.equal('5')
+  })
+
+  it('writes optional cutover, publish, L2 start, and initial-batch sidecar values', () => {
+    const env = buildEthDaSubmitterPrepEnv({
+      batch: {
+        compression: 'none',
+        cutover: {
+          lastBatchHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+          lastBatchIndex: 4379,
+          nextRelayedDepositIndex: 24_922,
+          nextWithdrawIndex: 13_047,
+          relayedDepositQueueHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+          stateRoot: '0x3333333333333333333333333333333333333333333333333333333333333333',
+          withdrawRoot: '0x4444444444444444444444444444444444444444444444444444444444444444',
+        },
+        initialBatchSidecarJson: '{"batch":4380}',
+        maxL2GasPerChunk: 30_000_000,
+      },
+      ethereumChainId: 1,
+      ethereumRpcUrl: 'https://eth.example',
+      l2ChainId: 6_281_971,
+      l2RpcUrl: 'http://l2-rpc:8545',
+      l2StartBlockNumber: 2_898_792,
+      publish: {
+        allowLivenessBudgetOverride: true,
+        maxBatchWait: '60s',
+        targetBlobsPerTx: 2,
+      },
+    })
+
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_L2__START_BLOCK_NUMBER).to.equal('2898792')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__COMPRESSION).to.equal('none')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_BATCH_HASH).to.equal('0x1111111111111111111111111111111111111111111111111111111111111111')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_WITHDRAW_ROOT).to.equal('0x4444444444444444444444444444444444444444444444444444444444444444')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_INDEX).to.equal('4379')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__WITHDRAW_ROOT).to.equal('0x4444444444444444444444444444444444444444444444444444444444444444')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__INITIAL_BATCH_SIDECAR_JSON).to.equal('/app/config/initial_batch.json')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_BLOCKS_PER_CHUNK).to.equal('128')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_L2_GAS_PER_CHUNK).to.equal('30000000')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__ALLOW_LIVENESS_BUDGET_OVERRIDE).to.equal('true')
+    expect(env.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__TARGET_BLOBS_PER_TX).to.equal('2')
+
+    const values: any = { configMaps: { env: { data: {} } }, persistence: {} }
+    const changes = applyEthDaSubmitterInitialBatchSidecar(values, '  {"batch":4380}  ')
+
+    expect(changes.map(change => change.key)).to.include('configMaps.initial-batch')
+    expect(values.configMaps['initial-batch'].data['initial_batch.json']).to.equal('{"batch":4380}')
+    expect(values.persistence['initial-batch'].mountPath).to.equal('/app/config')
+  })
+
+  it('does not emit an initial-batch sidecar env or mount for whitespace', () => {
+    const env = buildEthDaSubmitterPrepEnv({
+      batch: { initialBatchSidecarJson: '   ' },
+      ethereumChainId: 1,
+      ethereumRpcUrl: 'https://eth.example',
+      l2ChainId: 6_281_971,
+      l2RpcUrl: 'http://l2-rpc:8545',
+    })
+
+    expect(env).not.to.have.property('DOGEOS_ETH_DA_SUBMITTER_BATCH__INITIAL_BATCH_SIDECAR_JSON')
+
+    const values: any = { configMaps: { env: { data: {} } }, persistence: {} }
+    const changes = applyEthDaSubmitterInitialBatchSidecar(values, '   ')
+
+    expect(changes).to.deep.equal([])
+    expect(values.configMaps).not.to.have.property('initial-batch')
+    expect(values.persistence).not.to.have.property('initial-batch')
+  })
+
+  it('throws on invalid initial-batch sidecar JSON', () => {
+    expect(() => buildEthDaSubmitterPrepEnv({
+      batch: { initialBatchSidecarJson: '{"batch":' },
+      ethereumChainId: 1,
+      ethereumRpcUrl: 'https://eth.example',
+      l2ChainId: 6_281_971,
+      l2RpcUrl: 'http://l2-rpc:8545',
+    })).to.throw(/ethereumDa\.batch\.initialBatchSidecarJson/)
+
+    expect(() => applyEthDaSubmitterInitialBatchSidecar({}, '{"batch":')).to.throw(/ethereumDa\.batch\.initialBatchSidecarJson/)
+  })
+
+  it('validates doge-config cutover and L2 start block together', () => {
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      l2StartBlockNumber: 0,
+    })).to.throw(/ethereumDa\.batch\.cutover/)
+
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: { cutover: VALID_PREP_CUTOVER },
+    })).to.throw(/ethereumDa\.l2StartBlockNumber/)
+
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: { cutover: VALID_PREP_CUTOVER },
+      l2StartBlockNumber: 0,
+    })).not.to.throw()
+  })
+
+  it('validates doge-config hash, sidecar, and publish fields', () => {
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: {
+        compression: 'gzip' as any,
+      },
+    })).to.throw(/ethereumDa\.batch\.compression/)
+
+    const cutoverWithMissingIndex = { ...VALID_PREP_CUTOVER }
+    delete (cutoverWithMissingIndex as any).nextWithdrawIndex
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: {
+        cutover: cutoverWithMissingIndex,
+      },
+      l2StartBlockNumber: 0,
+    })).to.throw(/ethereumDa\.batch\.cutover\.nextWithdrawIndex/)
+
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: {
+        genesisStateRoot: '0x1234',
+      },
+    })).to.throw(/ethereumDa\.batch\.genesisStateRoot/)
+
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      batch: {
+        initialBatchSidecarJson: '{"batch":',
+      },
+    })).to.throw(/ethereumDa\.batch\.initialBatchSidecarJson/)
+
+    expect(() => validateDogeConfigEthereumDaForPrep({
+      publish: {
+        maxBatchWait: '',
+        targetBlobsPerTx: 0,
+      },
+    })).to.throw(/ethereumDa\.publish/)
   })
 })
 

--- a/test/commands/setup/prep-charts.test.ts
+++ b/test/commands/setup/prep-charts.test.ts
@@ -334,11 +334,13 @@ describe('setup prep-charts Ethereum DA blob source updates', () => {
   it('writes S3 blob source env for l1-interface', () => {
     const env = buildL1InterfaceBlobSourcePrepEnv({
       beaconRpcUrl: 'https://beacon.example',
+      s3KeyPrefix: 'devnet/eth-da/blobs/v1',
       s3PublicBaseUrl: 'https://dogeos-da.s3.us-east-1.amazonaws.com/',
       s3TimeoutMs: 15_000,
       s3TreatForbiddenAsMissing: false,
     })
 
+    expect(env.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1')
     expect(env.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/')
     expect(env.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS).to.equal('15000')
     expect(env.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING).to.equal('false')
@@ -374,11 +376,13 @@ describe('setup prep-charts Ethereum DA blob source updates', () => {
   it('writes S3 blob source env for withdrawal-processor', () => {
     const env = buildWithdrawalBlobSourcePrepEnv({
       beaconRpcUrl: 'https://beacon.example',
+      s3KeyPrefix: 'devnet/eth-da/blobs/v1',
       s3PublicBaseUrl: 'https://dogeos-da.s3.us-east-1.amazonaws.com/',
       s3TimeoutMs: '15000',
       s3TreatForbiddenAsMissing: 'false',
     })
 
+    expect(env.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1')
     expect(env.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/')
     expect(env.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS).to.equal('15000')
     expect(env.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING).to.equal('false')

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -138,6 +138,18 @@ function createMinimalSpec(overrides?: Partial<DeploymentSpec>): DeploymentSpec 
   } as DeploymentSpec;
 }
 
+function createValidEthereumDaCutover(): NonNullable<NonNullable<NonNullable<DeploymentSpec['ethereumDa']>['batch']>['cutover']> {
+  return {
+    lastBatchHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    lastBatchIndex: 4379,
+    nextRelayedDepositIndex: 24_922,
+    nextWithdrawIndex: 13_047,
+    relayedDepositQueueHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+    stateRoot: '0x3333333333333333333333333333333333333333333333333333333333333333',
+    withdrawRoot: '0x4444444444444444444444444444444444444444444444444444444444444444',
+  };
+}
+
 describe('deployment-spec-generator', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -459,6 +471,162 @@ describe('deployment-spec-generator', () => {
       expect(result.errors.some(error =>
         error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
         error.path === 'ethereumDa.inboxWorker.startBlock'
+      )).to.be.true;
+    });
+
+    it('allows Ethereum DA L2 start block zero', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.batch = {
+        cutover: createValidEthereumDaCutover(),
+      };
+      spec.ethereumDa!.l2StartBlockNumber = 0;
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.true;
+      expect(result.errors.some(error => error.path === 'ethereumDa.l2StartBlockNumber')).to.be.false;
+    });
+
+    it('fails when Ethereum DA batch hash fields are malformed', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.batch = {
+        genesisStateRoot: '0x1234',
+      };
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.genesisStateRoot'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA batch compression is invalid', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.batch = {
+        compression: 'gzip' as any,
+      };
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.compression'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA cutover hash fields are malformed', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.l2StartBlockNumber = 0;
+      spec.ethereumDa!.batch = {
+        cutover: {
+          lastBatchHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+          lastBatchIndex: 4379,
+          nextRelayedDepositIndex: 24_922,
+          nextWithdrawIndex: 13_047,
+          relayedDepositQueueHash: 'not-a-hash',
+          stateRoot: '0x3333333333333333333333333333333333333333333333333333333333333333',
+          withdrawRoot: '0x4444444444444444444444444444444444444444444444444444444444444444',
+        },
+      };
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.cutover.relayedDepositQueueHash'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA cutover indices are missing', () => {
+      const spec = createMinimalSpec();
+      const cutover = createValidEthereumDaCutover();
+      delete (cutover as any).nextWithdrawIndex;
+      spec.ethereumDa!.l2StartBlockNumber = 0;
+      spec.ethereumDa!.batch = {
+        cutover,
+      };
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.cutover.nextWithdrawIndex'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA cutover and L2 start block are not configured together', () => {
+      const cutoverOnlySpec = createMinimalSpec();
+      cutoverOnlySpec.ethereumDa!.batch = {
+        cutover: createValidEthereumDaCutover(),
+      };
+
+      const cutoverOnlyResult = validateDeploymentSpec(cutoverOnlySpec);
+      expect(cutoverOnlyResult.valid).to.be.false;
+      expect(cutoverOnlyResult.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.l2StartBlockNumber'
+      )).to.be.true;
+
+      const l2StartOnlySpec = createMinimalSpec();
+      l2StartOnlySpec.ethereumDa!.l2StartBlockNumber = 0;
+
+      const l2StartOnlyResult = validateDeploymentSpec(l2StartOnlySpec);
+      expect(l2StartOnlyResult.valid).to.be.false;
+      expect(l2StartOnlyResult.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.cutover'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA initial batch sidecar JSON is invalid', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.batch = {
+        initialBatchSidecarJson: '   ',
+      };
+
+      const blankResult = validateDeploymentSpec(spec);
+      expect(blankResult.valid).to.be.false;
+      expect(blankResult.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.initialBatchSidecarJson'
+      )).to.be.true;
+
+      spec.ethereumDa!.batch.initialBatchSidecarJson = '{"batch":'
+      const invalidResult = validateDeploymentSpec(spec);
+      expect(invalidResult.valid).to.be.false;
+      expect(invalidResult.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.batch.initialBatchSidecarJson'
+      )).to.be.true;
+    });
+
+    it('fails when Ethereum DA publish fields are invalid', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa!.publish = {
+        maxBatchWait: '',
+        maxBlobsPerTx: 0,
+        maxPendingBlobTxs: -1,
+      };
+
+      const result = validateDeploymentSpec(spec);
+
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.publish.maxBatchWait'
+      )).to.be.true;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.publish.maxBlobsPerTx'
+      )).to.be.true;
+      expect(result.errors.some(error =>
+        error.code === 'E012_INVALID_ETHEREUM_DA_CONFIG' &&
+        error.path === 'ethereumDa.publish.maxPendingBlobTxs'
       )).to.be.true;
     });
 
@@ -795,6 +963,7 @@ describe('deployment-spec-generator', () => {
         s3: {
           bucket: 'dogeos-da',
           enabled: true,
+          keyPrefix: 'devnet/eth-da/blobs/v1',
           maxRetries: 5,
           publicBaseUrl: 'https://dogeos-da.s3.us-east-1.amazonaws.com/',
           region: 'us-east-1',
@@ -808,6 +977,7 @@ describe('deployment-spec-generator', () => {
       expect(parsed.ethereumDa.blobArchive.s3.enabled).to.equal(true);
       expect(parsed.ethereumDa.blobArchive.s3.bucket).to.equal('dogeos-da');
       expect(parsed.ethereumDa.blobArchive.s3.region).to.equal('us-east-1');
+      expect(parsed.ethereumDa.blobArchive.s3.keyPrefix).to.equal('devnet/eth-da/blobs/v1');
       expect(parsed.ethereumDa.blobArchive.s3.publicBaseUrl).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/');
       expect(parsed.ethereumDa.blobArchive.s3.timeoutMs).to.equal(15_000);
       expect(parsed.ethereumDa.blobArchive.s3.treatForbiddenAsMissing).to.equal(false);
@@ -1155,11 +1325,54 @@ describe('deployment-spec-generator', () => {
       expect(files['l2-sequencer-production.yaml']).to.include('L2GETH_L1_ENDPOINT: http://l1-interface:8545');
       expect(files['contracts-production.yaml']).to.include('SCROLL_L1_FEE_VAULT_ADDR: \'0x1111111111111111111111111111111111111111\'');
 
+      const submitterValues = yaml.load(files['eth-da-submitter-production.yaml']) as any;
+      const submitterEnv = submitterValues.configMaps.env.data;
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_WITHDRAW_ROOT).to.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_RELAYED_DEPOSIT_QUEUE_HASH).to.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_L2_GAS_PER_CHUNK).to.equal('6000000');
+      expect(submitterEnv).not.to.have.property('DOGEOS_ETH_DA_SUBMITTER_ETHEREUM__MAX_FEE_PER_GAS_WEI');
+
+      const l1InterfaceValuesForRuntime = yaml.load(files['l1-interface-production.yaml']) as any;
+      const l1InterfaceRuntimeEnv = l1InterfaceValuesForRuntime.configMaps.env.data;
+      expect(l1InterfaceRuntimeEnv.DOGEOS_L1_INTERFACE_L1_GAS_LIMIT).to.equal('30000000');
+      expect(l1InterfaceRuntimeEnv.DOGEOS_L1_INTERFACE_REPLAY_READ__MAINTAINER_ENABLED).to.equal('true');
+      expect(l1InterfaceRuntimeEnv.DOGEOS_L1_INTERFACE_REPLAY_READ__REQUIRE_FULL_VALIDATION).to.equal('false');
+
+      const withdrawalValuesForRuntime = yaml.load(files['withdrawal-processor-production.yaml']) as any;
+      const withdrawalRuntimeEnv = Object.fromEntries(withdrawalValuesForRuntime.env.map((item: any) => [item.name, item.value]));
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_INITIAL_BRIDGE_REDEEM_SCRIPT_HEX).to.equal('');
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_MAX_WITHDRAWAL_OUTPUTS_PER_TX).to.equal('256');
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_MAX_DEPOSITS_PER_ADVANCE_L1).to.equal('32');
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_PROOF_TASK_POLICY__SKIP_SCROLL_EXECUTION_PROOFS).to.equal('true');
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_PROOF_EXECUTION_WORKER__ENABLED).to.equal('false');
+      expect(withdrawalRuntimeEnv.DOGEOS_WITHDRAWAL_UTXO_MANAGER_INTERMEDIATE__BRIDGE_STRATEGY__STRATEGY).to.equal('band');
+      expect(withdrawalValuesForRuntime.externalSecrets['withdrawal-processor-secret-env'].data.map((item: any) => item.secretKey))
+        .to.include.members([
+          'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_USER',
+          'DOGEOS_WITHDRAWAL_DOGECOIN_RPC_PASS',
+          'DOGEOS_WITHDRAWAL_FEE_SIGNER_KEY',
+          'DOGEOS_WITHDRAWAL_SEQUENCER_SIGNER_KEY',
+        ]);
+
+      const tsoValues = yaml.load(files['tso-service-production.yaml']) as any;
+      const tsoEnv = Object.fromEntries(tsoValues.env.map((item: any) => [item.name, item.value]));
+      expect(tsoEnv.TIMEOUT_CHECK_INTERVAL_SECONDS).to.equal('60');
+      expect(tsoEnv.TSO_CORRECTNESS_MAX_PSBT_BASE64_LEN).to.equal('130048');
+      expect(tsoEnv.TSO_CUBESIGNER_MAX_PSBT_BASE64_LEN).to.equal('130048');
+
+      const cubesignerValues = yaml.load(files['cubesigner-signer-production.yaml']) as any;
+      const cubesignerEnv = Object.fromEntries(cubesignerValues.env.map((item: any) => [item.name, item.value]));
+      expect(cubesignerEnv.DOGEOS_CUBESIGNER_SIGNER_LOG_LEVEL).to.equal('info');
+      expect(cubesignerEnv.DOGEOS_CUBESIGNER_SIGNER_POLL_INTERVAL).to.equal('500');
+      expect(cubesignerEnv.CUBESIGNER_MAX_PSBT_BASE64_LEN).to.equal('130048');
+
       const feeOracleValues = yaml.load(files['fee-oracle-production.yaml']) as any;
       const feeOracleEnv = feeOracleValues.configMaps.env.data;
       expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__CONTRACT_WRITE_MODE).to.equal('dry_run');
       expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__ETH_RPC_URL).to.equal('https://sepolia.drpc.org');
-      expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI).to.equal('"0"');
+      expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__MIN_PRIORITY_FEE_PER_GAS_WEI).to.equal('0');
+      expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__GAS_ORACLE__FORMULA).to.equal('galileo');
+      expect(feeOracleEnv.DOGEOS_FEE_ORACLE_ETHEREUM_DA__UPDATE_POLICY__PRICE_UNAVAILABLE_FALLBACK).to.equal('hold_last');
       expect(feeOracleEnv.DOGEOS_FEE_ORACLE_L2__CHAIN_ID).to.equal(String(spec.network.l2ChainId));
       expect(feeOracleValues.envFrom).to.deep.equal([{ configMapRef: { name: 'fee-oracle-env' } }]);
       expect(files['fee-oracle-production.yaml']).not.to.include('DOGEOS_FEE_ORACLE_DOGECOIN__');
@@ -1196,12 +1409,69 @@ describe('deployment-spec-generator', () => {
       expect(explicitSubmitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_BATCH__COMPRESSION).to.equal('none');
     });
 
+    it('generates Ethereum DA cutover, publish, sidecar, and L2 bootstrap values', () => {
+      const spec = createMinimalSpec();
+      spec.ethereumDa = {
+        ...spec.ethereumDa!,
+        batch: {
+          cutover: {
+            lastBatchHash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+            lastBatchIndex: 4379,
+            nextRelayedDepositIndex: 24_922,
+            nextWithdrawIndex: 13_047,
+            relayedDepositQueueHash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+            stateRoot: '0x3333333333333333333333333333333333333333333333333333333333333333',
+            withdrawRoot: '0x4444444444444444444444444444444444444444444444444444444444444444',
+          },
+          initialBatchSidecarJson: '{"batch_index":4380}',
+          maxL2GasPerChunk: 30_000_000,
+        },
+        l2StartBlockNumber: 2_898_792,
+        publish: {
+          allowLivenessBudgetOverride: true,
+          maxBatchWait: '60s',
+          maxBlobsPerTx: 6,
+          targetBlobsPerTx: 2,
+        },
+      };
+
+      const files = generateValuesFiles(spec);
+      const submitterValues = yaml.load(files['eth-da-submitter-production.yaml']) as any;
+      const submitterEnv = submitterValues.configMaps.env.data;
+
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_L2__START_BLOCK_NUMBER).to.equal('2898792');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_BATCH_HASH).to.equal('0x1111111111111111111111111111111111111111111111111111111111111111');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__GENESIS_WITHDRAW_ROOT).to.equal('0x4444444444444444444444444444444444444444444444444444444444444444');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__CUTOVER__LAST_BATCH_INDEX).to.equal('4379');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__INITIAL_BATCH_SIDECAR_JSON).to.equal('/app/config/initial_batch.json');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_BATCH__MAX_L2_GAS_PER_CHUNK).to.equal('30000000');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__MAX_BATCH_WAIT).to.equal('60s');
+      expect(submitterEnv.DOGEOS_ETH_DA_SUBMITTER_PUBLISH__TARGET_BLOBS_PER_TX).to.equal('2');
+      expect(submitterValues.configMaps['initial-batch'].data['initial_batch.json']).to.equal('{"batch_index":4380}');
+      expect(submitterValues.persistence['initial-batch'].mountPath).to.equal('/app/config');
+
+      const l1InterfaceValues = yaml.load(files['l1-interface-production.yaml']) as any;
+      expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_REPLAY_READ__L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT).to.equal('2898792');
+
+      const withdrawalValues = yaml.load(files['withdrawal-processor-production.yaml']) as any;
+      const withdrawalEnv = Object.fromEntries(withdrawalValues.env.map((item: any) => [item.name, item.value]));
+      expect(withdrawalEnv.DOGEOS_WITHDRAWAL_L2_BOOTSTRAP_NEXT_STARTING_BLOCK_HEIGHT).to.equal('2898792');
+
+      const dogeConfig = toml.parse(generateDogeConfigToml(spec)) as any;
+      expect(dogeConfig.ethereumDa.l2StartBlockNumber).to.equal(2_898_792);
+      expect(dogeConfig.ethereumDa.batch.maxL2GasPerChunk).to.equal(30_000_000);
+      expect(dogeConfig.ethereumDa.batch.initialBatchSidecarJson).to.equal('{"batch_index":4380}');
+      expect(dogeConfig.ethereumDa.publish.targetBlobsPerTx).to.equal(2);
+      expect(dogeConfig.defaults.l2BootstrapNextStartingBlockHeight).to.equal('2898792');
+    });
+
     it('generates Ethereum DA S3 upload and readback env', () => {
       const spec = createMinimalSpec();
       spec.ethereumDa!.blobArchive = {
         s3: {
           bucket: 'dogeos-da',
           enabled: true,
+          keyPrefix: 'devnet/eth-da/blobs/v1',
           maxRetries: 5,
           publicBaseUrl: 'https://dogeos-da.s3.us-east-1.amazonaws.com/',
           region: 'us-east-1',
@@ -1219,6 +1489,7 @@ describe('deployment-spec-generator', () => {
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__ENABLED).to.equal('true');
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__BUCKET).to.equal('dogeos-da');
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__REGION).to.equal('us-east-1');
+      expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1');
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__MAX_RETRIES).to.equal('5');
       expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/');
       expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS).to.equal('15000');

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -1491,9 +1491,11 @@ describe('deployment-spec-generator', () => {
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__REGION).to.equal('us-east-1');
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1');
       expect(submitterValues.configMaps.env.data.DOGEOS_ETH_DA_SUBMITTER_S3__MAX_RETRIES).to.equal('5');
+      expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1');
       expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/');
       expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS).to.equal('15000');
       expect(l1InterfaceValues.configMaps.env.data.DOGEOS_L1_INTERFACE_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING).to.equal('false');
+      expect(withdrawalEnv.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__KEY_PREFIX).to.equal('devnet/eth-da/blobs/v1');
       expect(withdrawalEnv.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__URL).to.equal('https://dogeos-da.s3.us-east-1.amazonaws.com/');
       expect(withdrawalEnv.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TIMEOUT_MS).to.equal('15000');
       expect(withdrawalEnv.DOGEOS_WITHDRAWAL_ETHEREUM_DA__BLOB_SOURCE__AWS_S3__TREAT_FORBIDDEN_AS_MISSING).to.equal('false');


### PR DESCRIPTION
## Summary
- extend DeploymentSpec/doge-config Ethereum DA schema for cutover, publish, sidecar, and L2 bootstrap fields
- align generated Helm values for eth-da-submitter, fee-oracle, l1-interface, withdrawal-processor, TSO, and CubeSigner with current DogeOS core runtime config
- update prep-charts normalization so existing values can be brought forward without regenerating everything

## Validation
- yarn build
- yarn test

## Notes
- Draft PR for Linear DOG-382.
- DOG-383 remains a separate cleanup follow-up for stale examples and generated-output cleanup.
- The implementation does not copy live devnet secrets or initial-batch payloads; operators provide environment-specific cutover values via DeploymentSpec/doge-config.