### PR TITLE
feat: generate scroll-reth execution client values

### DIFF
--- a/src/commands/setup/gen-rpc-package.ts
+++ b/src/commands/setup/gen-rpc-package.ts
@@ -11,6 +11,47 @@ import type { DogeConfig } from '../../types/doge-config.js'
 
 import { loadDogeConfigWithSelection } from '../../utils/doge-config.js'
 
+export function buildL2RethEnvVars(
+  config: any,
+  dogeConfig: DogeConfig,
+  peerListValue: string | undefined,
+  validSigner: string,
+): Record<string, string> {
+  const rethVars: Record<string, string> = {
+    L2RETH_BEACON_ENDPOINT: 'http://l1-interface:5052',
+    L2RETH_L1_ENDPOINT: 'http://l1-interface:8545',
+    L2RETH_VALID_SIGNER: validSigner,
+  }
+
+  if (config?.general?.CHAIN_ID_L2 !== undefined) {
+    rethVars.CHAIN_ID = config.general.CHAIN_ID_L2.toString()
+  }
+
+  if (dogeConfig?.defaults?.dogecoinIndexerStartHeight !== undefined) {
+    rethVars.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK = dogeConfig.defaults.dogecoinIndexerStartHeight
+  }
+
+  if (peerListValue) {
+    rethVars.L2RETH_PEER_LIST = peerListValue
+  }
+
+  return rethVars
+}
+
+export function buildL2RethEnvContent(networkTitleCase: string, rethVars: Record<string, string>): string {
+  const rethLines = [
+    `# L2Reth ${networkTitleCase} Configuration`,
+    '# Generated for external RPC package usage',
+    '',
+    '# Network specific settings',
+    ...Object.entries(rethVars)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => `${key}=${value}`),
+  ]
+
+  return rethLines.join('\n') + '\n'
+}
+
 export default class SetupGenRpcPackage extends Command {
   static override description = 'Generate configuration files for dogeos-rpc-package to enable external RPC nodes'
 
@@ -135,8 +176,8 @@ export default class SetupGenRpcPackage extends Command {
         this.log(chalk.red(`  Warning: No L1 RPC endpoint found in config`))
       }
 
-      const envFilePath = this.generateL2GethEnvFile(config, dogeConfig, rpcPackageDir, loadBalancerDomains, namespace)
-      this.log(chalk.green(`✓ Generated .env at: ${envFilePath}`))
+      const envFilePaths = this.generateL2GethEnvFile(config, dogeConfig, rpcPackageDir, loadBalancerDomains, namespace)
+      this.log(chalk.green(`✓ Generated .env files at: ${envFilePaths.join(', ')}`))
 
       // Step 7: Extract genesis.json from genesis.yaml
       this.log(chalk.blue('Step 3: Extracting genesis.json from genesis.yaml...'))
@@ -152,7 +193,9 @@ export default class SetupGenRpcPackage extends Command {
       this.log(chalk.green('🎉 RPC package generation completed successfully!'))
       this.log('')
       this.log(chalk.blue('Generated files:'))
-      this.log(chalk.cyan(`  - ${envFilePath}`))
+      for (const envFilePath of envFilePaths) {
+        this.log(chalk.cyan(`  - ${envFilePath}`))
+      }
       this.log(chalk.cyan(`  - ${genesisJsonPath}`))
       this.log(chalk.cyan(`  - ${l1InterfaceEnvPath}`))
       this.log('')
@@ -257,9 +300,24 @@ export default class SetupGenRpcPackage extends Command {
       fs.writeFileSync(genesisJsonPath, genesisJsonContent)
 
       // genesisJson for reth
-      const genesisJsonForReth = JSON.parse(JSON.stringify(genesisJson));
-      genesisJsonForReth.config.scroll.l1Config.startL1Block = dogeConfig.defaults?.dogecoinIndexerStartHeight;
-      genesisJsonForReth.config.scroll.l1Config.systemContractAddress = genesisJsonForReth.config.systemContract.system_contract_address;
+      const genesisJsonForReth = JSON.parse(JSON.stringify(genesisJson))
+      const rethL1Config = genesisJsonForReth.config?.scroll?.l1Config
+      if (!rethL1Config || typeof rethL1Config !== 'object') {
+        throw new Error('Missing required reth genesis field: config.scroll.l1Config')
+      }
+
+      const systemContractAddress = genesisJsonForReth.config?.systemContract?.system_contract_address
+      if (!systemContractAddress || typeof systemContractAddress !== 'string') {
+        throw new Error('Missing required reth genesis field: config.systemContract.system_contract_address')
+      }
+
+      const startL1Block = dogeConfig.defaults?.dogecoinIndexerStartHeight
+      if (startL1Block === undefined) {
+        throw new Error('Missing required DogeOS field: defaults.dogecoinIndexerStartHeight')
+      }
+
+      rethL1Config.startL1Block = startL1Block
+      rethL1Config.systemContractAddress = systemContractAddress
       fs.writeFileSync(path.join(targetDirectory, 'l2reth-genesis.json'), JSON.stringify(genesisJsonForReth, null, 2))
 
       return genesisJsonPath
@@ -481,14 +539,17 @@ export default class SetupGenRpcPackage extends Command {
       updatedVars.push('L2GETH_PEER_LIST')
     }
 
+    let validSigner = ''
     if (config?.sequencer?.L2GETH_SIGNER_ADDRESS) {
-      newVars.L2RETH_VALID_SIGNER = config.sequencer.L2GETH_SIGNER_ADDRESS;
-      updatedVars.push('L2RETH_VALID_SIGNER')
+      validSigner = config.sequencer.L2GETH_SIGNER_ADDRESS
     } else {
-      this.error('Missing required configuration: sequencer.L2GETH_SIGNER_ADDRESS in config.toml');
+      this.error('Missing required configuration: sequencer.L2GETH_SIGNER_ADDRESS in config.toml')
     }
 
-    // If no updates needed, return early
+    const rethVars = buildL2RethEnvVars(config, dogeConfig, peerListValue, validSigner)
+    fs.writeFileSync(envFilePathReth, buildL2RethEnvContent(networkTitleCase, rethVars))
+
+    // If no l2geth updates are needed, return after ensuring l2reth.env exists.
     if (Object.keys(newVars).length === 0) {
       this.log(chalk.green('✓ No changes detected in l2geth.env - file is up to date'))
       return [envFilePath, envFilePathReth]
@@ -562,7 +623,6 @@ export default class SetupGenRpcPackage extends Command {
 
     const envContent = newLines.join('\n') + '\n'
     fs.writeFileSync(envFilePath, envContent)
-    fs.writeFileSync(envFilePathReth, envContent)
 
     // Log what was updated
     if (updatedVars.length > 0) {

--- a/src/commands/setup/gen-rpc-package.ts
+++ b/src/commands/setup/gen-rpc-package.ts
@@ -308,6 +308,10 @@ export default class SetupGenRpcPackage extends Command {
 
       // genesisJson for reth
       const genesisJsonForReth = JSON.parse(JSON.stringify(genesisJson))
+      genesisJsonForReth.config ??= {}
+      genesisJsonForReth.config.scroll ??= {}
+      genesisJsonForReth.config.scroll.l1DataFeeBufferCheck ??= false
+
       const rethL1Config = genesisJsonForReth.config?.scroll?.l1Config
       if (!rethL1Config || typeof rethL1Config !== 'object') {
         throw new Error('Missing required reth genesis field: config.scroll.l1Config')

--- a/src/commands/setup/gen-rpc-package.ts
+++ b/src/commands/setup/gen-rpc-package.ts
@@ -23,13 +23,17 @@ export function buildL2RethEnvVars(
     L2RETH_VALID_SIGNER: validSigner,
   }
 
-  if (config?.general?.CHAIN_ID_L2 !== undefined) {
-    rethVars.CHAIN_ID = config.general.CHAIN_ID_L2.toString()
+  if (config?.general?.CHAIN_ID_L2 === undefined) {
+    throw new Error('Missing required configuration: general.CHAIN_ID_L2 for l2reth.env CHAIN_ID')
   }
+  rethVars.CHAIN_ID = config.general.CHAIN_ID_L2.toString()
 
-  if (dogeConfig?.defaults?.dogecoinIndexerStartHeight !== undefined) {
-    rethVars.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK = dogeConfig.defaults.dogecoinIndexerStartHeight
+  if (dogeConfig?.defaults?.dogecoinIndexerStartHeight === undefined) {
+    throw new Error(
+      'Missing required DogeOS field: defaults.dogecoinIndexerStartHeight for l2reth.env L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK',
+    )
   }
+  rethVars.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK = dogeConfig.defaults.dogecoinIndexerStartHeight
 
   if (peerListValue) {
     rethVars.L2RETH_PEER_LIST = peerListValue

--- a/src/commands/setup/gen-rpc-package.ts
+++ b/src/commands/setup/gen-rpc-package.ts
@@ -26,6 +26,7 @@ export function buildL2RethEnvVars(
   if (config?.general?.CHAIN_ID_L2 === undefined) {
     throw new Error('Missing required configuration: general.CHAIN_ID_L2 for l2reth.env CHAIN_ID')
   }
+
   rethVars.CHAIN_ID = config.general.CHAIN_ID_L2.toString()
 
   if (dogeConfig?.defaults?.dogecoinIndexerStartHeight === undefined) {
@@ -33,6 +34,7 @@ export function buildL2RethEnvVars(
       'Missing required DogeOS field: defaults.dogecoinIndexerStartHeight for l2reth.env L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK',
     )
   }
+
   rethVars.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK = dogeConfig.defaults.dogecoinIndexerStartHeight
 
   if (peerListValue) {
@@ -200,6 +202,7 @@ export default class SetupGenRpcPackage extends Command {
       for (const envFilePath of envFilePaths) {
         this.log(chalk.cyan(`  - ${envFilePath}`))
       }
+
       this.log(chalk.cyan(`  - ${genesisJsonPath}`))
       this.log(chalk.cyan(`  - ${l1InterfaceEnvPath}`))
       this.log('')

--- a/src/commands/setup/prep-charts.ts
+++ b/src/commands/setup/prep-charts.ts
@@ -409,6 +409,8 @@ export default class SetupPrepCharts extends Command {
     'L2GETH_PEER_LIST': 'sequencer.L2_GETH_STATIC_PEERS',
     'L2GETH_SIGNER_ADDRESS': (chartName, productionNumber) =>
       productionNumber === '0' ? 'sequencer.L2GETH_SIGNER_ADDRESS' : `sequencer.sequencer-${productionNumber}.L2GETH_SIGNER_ADDRESS`,
+    'L2RETH_VALID_SIGNER': (chartName, productionNumber) =>
+      productionNumber === '0' ? 'sequencer.L2GETH_SIGNER_ADDRESS' : `sequencer.sequencer-${productionNumber}.L2GETH_SIGNER_ADDRESS`,
     'ROLLUP_EXPLORER_API_HOST': 'ingress.ROLLUP_EXPLORER_API_HOST',
     'RPC_GATEWAY_HOST': 'ingress.RPC_GATEWAY_HOST',
     'RPC_GATEWAY_WS_HOST': 'ingress.RPC_GATEWAY_WS_HOST',

--- a/src/config/deployment-spec.example.yaml
+++ b/src/config/deployment-spec.example.yaml
@@ -197,6 +197,10 @@ test:
   mockFinalizeEnabled: false
   mockFinalizeTimeoutSec: 7200
 
+executionClient:
+  # Experimental opt-in backend. Use l2geth unless explicitly testing scroll-reth.
+  backend: l2geth # l2geth | scroll-reth
+
 # Container image overrides (optional)
 # Use this section to customize images for testing, development, or custom builds.
 # All fields are optional - omit a service to use Helm chart defaults.
@@ -205,7 +209,7 @@ images:
     pullPolicy: IfNotPresent    # Default pull policy for all services
 
   services:
-    # L2 Execution Layer (Geth-based)
+    # L2 Execution Layer
     l2Sequencer:
       repository: scrolltech/l2geth
       tag: scroll-v5.9.6

--- a/src/types/deployment-spec.ts
+++ b/src/types/deployment-spec.ts
@@ -32,6 +32,9 @@ export interface DeploymentSpec {
   /** Ethereum DA configuration */
   ethereumDa?: EthereumDaConfig
 
+  /** L2 execution client configuration */
+  executionClient?: ExecutionClientConfig
+
   /** Frontend and ingress configuration */
   frontend: FrontendConfig
 
@@ -422,6 +425,11 @@ export interface EthereumDaSignerConfig {
   namespace?: string
   serviceAccountName?: string
   serviceAccountRoleArn?: string
+}
+
+export interface ExecutionClientConfig {
+  /** L2 execution backend. Defaults to l2geth. */
+  backend?: 'l2geth' | 'scroll-reth'
 }
 
 export interface BridgeConfig {

--- a/src/utils/deployment-spec-generator.ts
+++ b/src/utils/deployment-spec-generator.ts
@@ -505,6 +505,9 @@ export function normalizeDeploymentSpec(spec: DeploymentSpec): DeploymentSpec {
       ...spec.contracts,
       ...(verification ? { verification } : {}),
     },
+    executionClient: {
+      backend: spec.executionClient?.backend || 'l2geth',
+    },
     frontend: {
       ...spec.frontend,
       baseDomain,
@@ -551,6 +554,14 @@ export function validateDeploymentSpec(rawSpec: DeploymentSpec): ValidationResul
       code: 'E001_UNSUPPORTED_VERSION',
       message: `Unsupported version: ${spec.version}. Expected: 1.0`,
       path: 'version'
+    })
+  }
+
+  if (spec.executionClient?.backend && !['l2geth', 'scroll-reth'].includes(spec.executionClient.backend)) {
+    errors.push({
+      code: 'E013_INVALID_EXECUTION_CLIENT_BACKEND',
+      message: `Invalid execution client backend: ${String(spec.executionClient.backend)}. Must be one of: l2geth, scroll-reth`,
+      path: 'executionClient.backend',
     })
   }
 

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -195,7 +195,7 @@ function buildScrollRethEnv(
     L2RETH_EXTRA_PARAMS: '',
     L2RETH_GENESIS: SCROLL_RETH_GENESIS_PATH,
     L2RETH_HTTP_PORT: '8545',
-    L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: String(spec.contracts.l1DeploymentBlock || 0),
+    L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: String(getDogecoinIndexerStartHeight(spec)),
     L2RETH_L1_ENDPOINT: L1_INTERFACE_RPC_ENDPOINT,
     L2RETH_P2P_PORT: '30303',
     L2RETH_PEER_LIST: JSON.stringify(peerList.length > 0 ? peerList : []),
@@ -343,6 +343,23 @@ function resolveImage(
   }
 }
 
+function resolveScrollRethImage(
+  spec: DeploymentSpec,
+  serviceKey: ServiceImageKey
+): { pullPolicy: 'Always' | 'IfNotPresent' | 'Never'; repository: string; tag: string } {
+  const imagesConfig = spec.images
+  const serviceConfig = imagesConfig?.services?.[serviceKey]
+  const defaultPullPolicy = imagesConfig?.defaults?.pullPolicy || DEFAULT_SCROLL_RETH_IMAGE.pullPolicy
+  const hasL2GethRepository = serviceConfig?.repository === DEFAULT_L2GETH_IMAGE.repository
+  const hasL2GethTag = serviceConfig?.tag === DEFAULT_L2GETH_IMAGE.tag
+
+  return {
+    pullPolicy: serviceConfig?.pullPolicy || defaultPullPolicy,
+    repository: hasL2GethRepository ? DEFAULT_SCROLL_RETH_IMAGE.repository : serviceConfig?.repository || DEFAULT_SCROLL_RETH_IMAGE.repository,
+    tag: (hasL2GethRepository || hasL2GethTag) ? DEFAULT_SCROLL_RETH_IMAGE.tag : serviceConfig?.tag || DEFAULT_SCROLL_RETH_IMAGE.tag
+  }
+}
+
 /**
  * Generate all Helm values files from a DeploymentSpec
  */
@@ -419,7 +436,7 @@ function generateL2SequencerValues(spec: DeploymentSpec): string {
   }
 
   if (isScrollRethBackend(spec)) {
-    const image = resolveImage(spec, 'l2Sequencer', DEFAULT_SCROLL_RETH_IMAGE)
+    const image = resolveScrollRethImage(spec, 'l2Sequencer')
     const values: Record<string, any> = {
       command: SCROLL_RETH_COMMAND,
       configMaps: {
@@ -577,7 +594,7 @@ function generateL2BootnodeValues(spec: DeploymentSpec): string {
   const peerList = buildPeerList(spec)
 
   if (isScrollRethBackend(spec)) {
-    const image = resolveImage(spec, 'l2Bootnode', DEFAULT_SCROLL_RETH_IMAGE)
+    const image = resolveScrollRethImage(spec, 'l2Bootnode')
     const values: Record<string, any> = {
       command: SCROLL_RETH_COMMAND,
       configMaps: {
@@ -730,7 +747,7 @@ function generateL2RpcValues(spec: DeploymentSpec): string {
   const peerList = buildPeerList(spec)
 
   if (isScrollRethBackend(spec)) {
-    const image = resolveImage(spec, 'l2Rpc', DEFAULT_SCROLL_RETH_IMAGE)
+    const image = resolveScrollRethImage(spec, 'l2Rpc')
     const values: Record<string, any> = {
       command: SCROLL_RETH_COMMAND,
       configMaps: {

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -173,6 +173,7 @@ const DEFAULT_SCROLL_RETH_IMAGE = {
 const SCROLL_RETH_DATADIR = '/l2reth/reth-data'
 const SCROLL_RETH_GENESIS_PATH = '/l2reth/genesis/genesis.json'
 const SCROLL_RETH_COMMAND = ['bash', '-c', 'exec dogeos-reth-entrypoint']
+const SCROLL_RETH_METRICS_PARAMS = '--metrics 0.0.0.0:6060'
 
 function getExecutionClientBackend(spec: DeploymentSpec): ExecutionClientBackend {
   return spec.executionClient?.backend ?? 'l2geth'
@@ -188,11 +189,13 @@ function buildScrollRethEnv(
   peerList: string[],
   signerAddress = '',
 ): Record<string, string> {
+  const extraParams = role === 'bootnode' ? '' : SCROLL_RETH_METRICS_PARAMS
+
   return {
     CHAIN_ID: String(spec.network.l2ChainId),
     L2RETH_BEACON_ENDPOINT: L1_INTERFACE_BEACON_API_ENDPOINT,
     L2RETH_DATADIR: SCROLL_RETH_DATADIR,
-    L2RETH_EXTRA_PARAMS: '',
+    L2RETH_EXTRA_PARAMS: extraParams,
     L2RETH_GENESIS: SCROLL_RETH_GENESIS_PATH,
     L2RETH_HTTP_PORT: '8545',
     L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: String(getDogecoinIndexerStartHeight(spec)),
@@ -490,6 +493,11 @@ function generateL2SequencerValues(spec: DeploymentSpec): string {
           type: 'configMap'
         }
       },
+      probes: {
+        liveness: { enabled: false },
+        readiness: { enabled: false },
+        startup: { enabled: false }
+      },
       resources: {
         limits: { cpu: '4', memory: '8Gi' },
         requests: { cpu: '50m', memory: '150Mi' }
@@ -648,7 +656,11 @@ function generateL2BootnodeValues(spec: DeploymentSpec): string {
         }
       },
       service: {
+        main: { enabled: false },
         p2p: { enabled: true }
+      },
+      serviceMonitor: {
+        main: { enabled: false }
       }
     }
 
@@ -808,6 +820,11 @@ function generateL2RpcValues(spec: DeploymentSpec): string {
           name: 'genesis-config',
           type: 'configMap'
         }
+      },
+      probes: {
+        liveness: { enabled: false },
+        readiness: { enabled: false },
+        startup: { enabled: false }
       },
       volumeClaimTemplates: [
         {

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -156,9 +156,54 @@ function buildPeerList(spec: DeploymentSpec): string[] {
  * Service name to DeploymentSpec image key mapping
  */
 type ServiceImageKey = keyof NonNullable<ImagesConfig['services']>
+type ExecutionClientBackend = NonNullable<NonNullable<DeploymentSpec['executionClient']>['backend']>
 
 const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
 const DEFAULT_L1_FEE_VAULT_ADDR = '0x1111111111111111111111111111111111111111'
+const DEFAULT_L2GETH_IMAGE = {
+  pullPolicy: 'IfNotPresent' as const,
+  repository: 'scrolltech/l2geth',
+  tag: 'scroll-v5.9.6',
+}
+const DEFAULT_SCROLL_RETH_IMAGE = {
+  pullPolicy: 'IfNotPresent' as const,
+  repository: 'ghcr.io/dogeos69/scroll-reth',
+  tag: 'dogeos-revm-c1cd6f4',
+}
+const SCROLL_RETH_DATADIR = '/l2reth/reth-data'
+const SCROLL_RETH_GENESIS_PATH = '/l2reth/genesis/genesis.json'
+const SCROLL_RETH_COMMAND = ['bash', '-c', 'exec dogeos-reth-entrypoint']
+
+function getExecutionClientBackend(spec: DeploymentSpec): ExecutionClientBackend {
+  return spec.executionClient?.backend ?? 'l2geth'
+}
+
+function isScrollRethBackend(spec: DeploymentSpec): boolean {
+  return getExecutionClientBackend(spec) === 'scroll-reth'
+}
+
+function buildScrollRethEnv(
+  spec: DeploymentSpec,
+  role: 'bootnode' | 'rpc' | 'sequencer',
+  peerList: string[],
+  signerAddress = '',
+): Record<string, string> {
+  return {
+    CHAIN_ID: String(spec.network.l2ChainId),
+    L2RETH_BEACON_ENDPOINT: L1_INTERFACE_BEACON_API_ENDPOINT,
+    L2RETH_DATADIR: SCROLL_RETH_DATADIR,
+    L2RETH_EXTRA_PARAMS: '',
+    L2RETH_GENESIS: SCROLL_RETH_GENESIS_PATH,
+    L2RETH_HTTP_PORT: '8545',
+    L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK: String(spec.contracts.l1DeploymentBlock || 0),
+    L2RETH_L1_ENDPOINT: L1_INTERFACE_RPC_ENDPOINT,
+    L2RETH_P2P_PORT: '30303',
+    L2RETH_PEER_LIST: JSON.stringify(peerList.length > 0 ? peerList : []),
+    L2RETH_ROLE: role,
+    L2RETH_VALID_SIGNER: signerAddress,
+    L2RETH_WS_PORT: '8546',
+  }
+}
 
 const ETHEREUM_DA_DEFAULTS = {
   devnet: {
@@ -373,11 +418,79 @@ function generateL2SequencerValues(spec: DeploymentSpec): string {
     return ''
   }
 
-  const image = resolveImage(spec, 'l2Sequencer', {
-    pullPolicy: 'IfNotPresent',
-    repository: 'scrolltech/l2geth',
-    tag: 'scroll-v5.9.6'
-  })
+  if (isScrollRethBackend(spec)) {
+    const image = resolveImage(spec, 'l2Sequencer', DEFAULT_SCROLL_RETH_IMAGE)
+    const values: Record<string, any> = {
+      command: SCROLL_RETH_COMMAND,
+      configMaps: {
+        env: {
+          data: buildScrollRethEnv(spec, 'sequencer', peerList, getSignerAddress()),
+          enabled: true
+        }
+      },
+      env: [
+        { name: 'RUST_LOG', value: 'sqlx=off,scroll=trace,reth=trace,rollup=trace,info' }
+      ],
+      envFrom: [
+        { configMapRef: { name: 'l2-sequencer-__INSTANCE_INDEX__-env' } }
+      ],
+      global: {
+        fullnameOverride: 'l2-sequencer-__INSTANCE_INDEX__'
+      },
+      image,
+      initContainers: {
+        'wait-for-l1': {
+          command: ['/bin/sh', '-c', '/wait-for-l1.sh $L2RETH_L1_ENDPOINT'],
+          envFrom: [{ configMapRef: { name: 'l2-sequencer-__INSTANCE_INDEX__-env' } }],
+          image: 'scrolltech/scroll-alpine:v0.0.1',
+          volumeMounts: [{
+            mountPath: '/wait-for-l1.sh',
+            name: 'wait-for-l1-script',
+            subPath: 'wait-for-l1.sh'
+          }]
+        }
+      },
+      persistence: {
+        data: {
+          accessMode: 'ReadWriteOnce',
+          enabled: true,
+          mountPath: SCROLL_RETH_DATADIR,
+          name: 'l2reth-data',
+          retain: true,
+          size: '1000Gi',
+          type: 'pvc'
+        },
+        env: {
+          enabled: true,
+          name: 'l2-sequencer-__INSTANCE_INDEX__-env',
+          type: 'configMap'
+        },
+        genesis: {
+          enabled: true,
+          mountPath: SCROLL_RETH_GENESIS_PATH,
+          name: 'genesis-config',
+          subPath: 'genesis.json',
+          type: 'configMap'
+        }
+      },
+      resources: {
+        limits: { cpu: '4', memory: '8Gi' },
+        requests: { cpu: '50m', memory: '150Mi' }
+      }
+    }
+
+    if (spec.infrastructure.sequencers && spec.infrastructure.sequencers.length > 0) {
+      values._sequencerInstances = spec.infrastructure.sequencers.map(s => ({
+        enodeUrl: s.enodeUrl || 'generated-during-deployment',
+        index: s.index,
+        signerAddress: s.signerAddress
+      }))
+    }
+
+    return yaml.dump(values)
+  }
+
+  const image = resolveImage(spec, 'l2Sequencer', DEFAULT_L2GETH_IMAGE)
 
   const values: Record<string, any> = {
     configMaps: {
@@ -463,11 +576,77 @@ function generateL2BootnodeValues(spec: DeploymentSpec): string {
   const secretConfig = getSecretProviderConfig(spec)
   const peerList = buildPeerList(spec)
 
-  const image = resolveImage(spec, 'l2Bootnode', {
-    pullPolicy: 'IfNotPresent',
-    repository: 'scrolltech/l2geth',
-    tag: 'scroll-v5.9.6'
-  })
+  if (isScrollRethBackend(spec)) {
+    const image = resolveImage(spec, 'l2Bootnode', DEFAULT_SCROLL_RETH_IMAGE)
+    const values: Record<string, any> = {
+      command: SCROLL_RETH_COMMAND,
+      configMaps: {
+        env: {
+          data: buildScrollRethEnv(spec, 'bootnode', peerList),
+          enabled: true
+        }
+      },
+      env: [
+        { name: 'RUST_LOG', value: 'sqlx=off,scroll=trace,reth=trace,rollup=trace,info' }
+      ],
+      envFrom: [
+        { configMapRef: { name: 'l2-bootnode-__INSTANCE_INDEX__-env' } }
+      ],
+      global: {
+        fullnameOverride: 'l2-bootnode-__INSTANCE_INDEX__'
+      },
+      image,
+      initContainers: {
+        'wait-for-l1': {
+          command: ['/bin/sh', '-c', '/wait-for-l1.sh $L2RETH_L1_ENDPOINT'],
+          envFrom: [{ configMapRef: { name: 'l2-bootnode-__INSTANCE_INDEX__-env' } }],
+          image: 'scrolltech/scroll-alpine:v0.0.1',
+          volumeMounts: [{
+            mountPath: '/wait-for-l1.sh',
+            name: 'wait-for-l1-script',
+            subPath: 'wait-for-l1.sh'
+          }]
+        }
+      },
+      persistence: {
+        data: {
+          accessMode: 'ReadWriteOnce',
+          enabled: true,
+          mountPath: SCROLL_RETH_DATADIR,
+          retain: true,
+          size: '1000Gi',
+          type: 'pvc'
+        },
+        env: {
+          enabled: true,
+          mountPath: '/config/',
+          name: 'l2-bootnode-__INSTANCE_INDEX__-env',
+          type: 'configMap'
+        },
+        genesis: {
+          enabled: true,
+          mountPath: '/l2reth/genesis/',
+          name: 'genesis-config',
+          type: 'configMap'
+        }
+      },
+      service: {
+        p2p: { enabled: true }
+      }
+    }
+
+    if (spec.infrastructure.bootnodes && spec.infrastructure.bootnodes.length > 0) {
+      values._bootnodeInstances = spec.infrastructure.bootnodes.map(b => ({
+        enodeUrl: b.enodeUrl || 'generated-during-deployment',
+        index: b.index,
+        publicEndpoint: b.publicEndpoint
+      }))
+    }
+
+    return yaml.dump(values)
+  }
+
+  const image = resolveImage(spec, 'l2Bootnode', DEFAULT_L2GETH_IMAGE)
 
   const values: Record<string, any> = {
     configMaps: {
@@ -550,11 +729,83 @@ function generateL2BootnodeValues(spec: DeploymentSpec): string {
 function generateL2RpcValues(spec: DeploymentSpec): string {
   const peerList = buildPeerList(spec)
 
-  const image = resolveImage(spec, 'l2Rpc', {
-    pullPolicy: 'IfNotPresent',
-    repository: 'scrolltech/l2geth',
-    tag: 'scroll-v5.9.6'
-  })
+  if (isScrollRethBackend(spec)) {
+    const image = resolveImage(spec, 'l2Rpc', DEFAULT_SCROLL_RETH_IMAGE)
+    const values: Record<string, any> = {
+      command: SCROLL_RETH_COMMAND,
+      configMaps: {
+        env: {
+          data: buildScrollRethEnv(spec, 'rpc', peerList),
+          enabled: true
+        }
+      },
+      env: [
+        { name: 'RUST_LOG', value: 'sqlx=off,scroll=trace,reth=trace,rollup=trace,info' }
+      ],
+      envFrom: [
+        { configMapRef: { name: 'l2-rpc-env' } }
+      ],
+      global: {
+        fullnameOverride: 'l2-rpc'
+      },
+      image,
+      ingress: {
+        main: {
+          hosts: [{
+            host: spec.frontend.hosts.rpcGateway,
+            paths: [{ path: '/', pathType: 'Prefix' }]
+          }],
+          ingressClassName: 'nginx',
+          tls: [{
+            hosts: [spec.frontend.hosts.rpcGateway],
+            secretName: 'l2-rpc-tls'
+          }]
+        }
+      },
+      initContainers: {
+        '1-wait-for-l1': {
+          command: ['/bin/sh', '-c', '/wait-for-l1.sh $L2RETH_L1_ENDPOINT'],
+          envFrom: [{ configMapRef: { name: 'l2-rpc-env' } }],
+          image: 'scrolltech/scroll-alpine:v0.0.1',
+          volumeMounts: [{
+            mountPath: '/wait-for-l1.sh',
+            name: 'wait-for-l1-script',
+            subPath: 'wait-for-l1.sh'
+          }]
+        }
+      },
+      persistence: {
+        data: {
+          retain: true,
+          size: '1000Gi'
+        },
+        env: {
+          enabled: true,
+          mountPath: '/config/',
+          name: 'l2-rpc-env',
+          type: 'configMap'
+        },
+        genesis: {
+          enabled: true,
+          mountPath: '/l2reth/genesis/',
+          name: 'genesis-config',
+          type: 'configMap'
+        }
+      },
+      volumeClaimTemplates: [
+        {
+          accessMode: 'ReadWriteOnce',
+          mountPath: SCROLL_RETH_DATADIR,
+          name: 'data',
+          size: '1000Gi'
+        }
+      ]
+    }
+
+    return yaml.dump(values)
+  }
+
+  const image = resolveImage(spec, 'l2Rpc', DEFAULT_L2GETH_IMAGE)
 
   const values = {
     configMaps: {

--- a/src/utils/values-generator.ts
+++ b/src/utils/values-generator.ts
@@ -167,7 +167,7 @@ const DEFAULT_L2GETH_IMAGE = {
 }
 const DEFAULT_SCROLL_RETH_IMAGE = {
   pullPolicy: 'IfNotPresent' as const,
-  repository: 'ghcr.io/dogeos69/scroll-reth',
+  repository: 'vladogeos/scroll-reth',
   tag: 'dogeos-revm-c1cd6f4',
 }
 const SCROLL_RETH_DATADIR = '/l2reth/reth-data'

--- a/test/commands/setup/gen-rpc-package.test.ts
+++ b/test/commands/setup/gen-rpc-package.test.ts
@@ -27,4 +27,30 @@ describe('setup gen-rpc-package l2reth env generation', () => {
     expect(content).to.include('L2RETH_BEACON_ENDPOINT=http://l1-interface:5052')
     expect(content).not.to.include('L2GETH_')
   })
+
+  it('rejects missing L2 chain ID for l2reth.env', () => {
+    expect(() => buildL2RethEnvVars(
+      { general: {} },
+      {
+        defaults: { dogecoinIndexerStartHeight: '8200000' },
+        network: 'testnet',
+        wallet: { path: '/tmp/wallet.dat' },
+      },
+      undefined,
+      '0x1234567890123456789012345678901234567890',
+    )).to.throw('general.CHAIN_ID_L2')
+  })
+
+  it('rejects missing Dogecoin indexer start height for l2reth.env', () => {
+    expect(() => buildL2RethEnvVars(
+      { general: { CHAIN_ID_L2: 534_351 } },
+      {
+        defaults: {},
+        network: 'testnet',
+        wallet: { path: '/tmp/wallet.dat' },
+      },
+      undefined,
+      '0x1234567890123456789012345678901234567890',
+    )).to.throw('defaults.dogecoinIndexerStartHeight')
+  })
 })

--- a/test/commands/setup/gen-rpc-package.test.ts
+++ b/test/commands/setup/gen-rpc-package.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai'
+
+import {
+  buildL2RethEnvContent,
+  buildL2RethEnvVars,
+} from '../../../src/commands/setup/gen-rpc-package.js'
+
+describe('setup gen-rpc-package l2reth env generation', () => {
+  it('emits reth-specific env keys without L2GETH dependencies', () => {
+    const vars = buildL2RethEnvVars(
+      { general: { CHAIN_ID_L2: 534_351 } },
+      {
+        defaults: { dogecoinIndexerStartHeight: '8200000' },
+        network: 'testnet',
+        wallet: { path: '/tmp/wallet.dat' },
+      },
+      '["enode://bootnode@example.com:30303"]',
+      '0x1234567890123456789012345678901234567890',
+    )
+    const content = buildL2RethEnvContent('Testnet', vars)
+
+    expect(content).to.include('CHAIN_ID=534351')
+    expect(content).to.include('L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK=8200000')
+    expect(content).to.include('L2RETH_PEER_LIST=["enode://bootnode@example.com:30303"]')
+    expect(content).to.include('L2RETH_VALID_SIGNER=0x1234567890123456789012345678901234567890')
+    expect(content).to.include('L2RETH_L1_ENDPOINT=http://l1-interface:8545')
+    expect(content).to.include('L2RETH_BEACON_ENDPOINT=http://l1-interface:5052')
+    expect(content).not.to.include('L2GETH_')
+  })
+})

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -1206,7 +1206,7 @@ describe('deployment-spec-generator', () => {
       ];
 
       for (const output of l2Files) {
-        expect(output).to.include('ghcr.io/dogeos69/scroll-reth');
+        expect(output).to.include('vladogeos/scroll-reth');
         expect(output).to.include('dogeos-revm-c1cd6f4');
         expect(output).to.include('L2RETH_L1_ENDPOINT: http://l1-interface:8545');
         expect(output).to.include('exec dogeos-reth-entrypoint');

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -262,6 +262,15 @@ describe('deployment-spec-generator', () => {
       }
     });
 
+    it('defaults the execution client backend to l2geth', () => {
+      const spec = createMinimalSpec();
+      delete spec.executionClient;
+
+      const normalized = normalizeDeploymentSpec(spec);
+
+      expect(normalized.executionClient?.backend).to.equal('l2geth');
+    });
+
     it('derives frontend hosts and external URLs from baseDomain', () => {
       const spec = createMinimalSpec();
       (spec.frontend as any) = {
@@ -320,6 +329,13 @@ describe('deployment-spec-generator', () => {
       const result = validateDeploymentSpec(spec);
       expect(result.valid).to.be.true;
       expect(result.errors).to.have.lengthOf(0);
+    });
+
+    it('fails on unsupported execution client backend', () => {
+      const spec = createMinimalSpec({ executionClient: { backend: 'nethermind' as any } });
+      const result = validateDeploymentSpec(spec);
+      expect(result.valid).to.be.false;
+      expect(result.errors.some(e => e.path === 'executionClient.backend')).to.be.true;
     });
 
     it('fails on unsupported version', () => {
@@ -1166,6 +1182,53 @@ describe('deployment-spec-generator', () => {
       expect(files['fee-oracle-production.yaml']).not.to.include('DOGEOS_FEE_ORACLE_CELESTIA__');
       expect(files['fee-oracle-production.yaml']).not.to.include('FEE_ORACLE_DOGE_RPC_URL');
       expect(feeOracleValues).not.to.have.property('externalSecrets');
+    });
+
+    it('generates scroll-reth L2 values when executionClient backend is scroll-reth', () => {
+      const spec = createMinimalSpec();
+      spec.executionClient = { backend: 'scroll-reth' };
+      spec.infrastructure.sequencers = [{
+        enodeUrl: 'enode://sequencer@example.com:30303',
+        index: 0,
+        signerAddress: '0x1234567890123456789012345678901234567890',
+      }];
+      spec.infrastructure.bootnodes = [{
+        enodeUrl: 'enode://bootnode@example.com:30303',
+        index: 0,
+        publicEndpoint: 'bootnode.example.com:30303',
+      }];
+
+      const files = generateValuesFiles(spec);
+      const l2Files = [
+        files['l2-sequencer-production.yaml'],
+        files['l2-bootnode-production.yaml'],
+        files['l2-rpc-production.yaml'],
+      ];
+
+      for (const output of l2Files) {
+        expect(output).to.include('ghcr.io/dogeos69/scroll-reth');
+        expect(output).to.include('dogeos-revm-c1cd6f4');
+        expect(output).to.include('L2RETH_L1_ENDPOINT: http://l1-interface:8545');
+        expect(output).to.include('exec dogeos-reth-entrypoint');
+        expect(output).not.to.include('L2GETH_');
+      }
+
+      const sequencerValues = yaml.load(files['l2-sequencer-production.yaml']) as any;
+      expect(sequencerValues.command).to.deep.equal(['bash', '-c', 'exec dogeos-reth-entrypoint']);
+      expect(sequencerValues.configMaps.env.data.L2RETH_ROLE).to.equal('sequencer');
+      expect(sequencerValues.configMaps.env.data.L2RETH_VALID_SIGNER).to.equal('__SEQUENCER_SIGNER_ADDRESS__');
+      expect(sequencerValues.envFrom).to.deep.equal([{ configMapRef: { name: 'l2-sequencer-__INSTANCE_INDEX__-env' } }]);
+      expect(sequencerValues.persistence.data.mountPath).to.equal('/l2reth/reth-data');
+      expect(sequencerValues.persistence.genesis.mountPath).to.equal('/l2reth/genesis/genesis.json');
+      expect(sequencerValues).not.to.have.property('externalSecrets');
+
+      const bootnodeValues = yaml.load(files['l2-bootnode-production.yaml']) as any;
+      expect(bootnodeValues.configMaps.env.data.L2RETH_ROLE).to.equal('bootnode');
+      expect(bootnodeValues.persistence.data.mountPath).to.equal('/l2reth/reth-data');
+
+      const rpcValues = yaml.load(files['l2-rpc-production.yaml']) as any;
+      expect(rpcValues.configMaps.env.data.L2RETH_ROLE).to.equal('rpc');
+      expect(rpcValues.volumeClaimTemplates[0].mountPath).to.equal('/l2reth/reth-data');
     });
 
     it('generates l1-interface genesis and indexer heights independently', () => {

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -1187,6 +1187,15 @@ describe('deployment-spec-generator', () => {
     it('generates scroll-reth L2 values when executionClient backend is scroll-reth', () => {
       const spec = createMinimalSpec();
       spec.executionClient = { backend: 'scroll-reth' };
+      spec.contracts.l1DeploymentBlock = 123;
+      spec.dogecoin.indexerStartHeight = 8_200_000;
+      spec.images = {
+        services: {
+          l2Bootnode: { repository: 'scrolltech/l2geth', tag: 'scroll-v5.9.6' },
+          l2Rpc: { repository: 'scrolltech/l2geth', tag: 'scroll-v5.9.6' },
+          l2Sequencer: { repository: 'scrolltech/l2geth', tag: 'scroll-v5.9.6' },
+        },
+      };
       spec.infrastructure.sequencers = [{
         enodeUrl: 'enode://sequencer@example.com:30303',
         index: 0,
@@ -1216,6 +1225,7 @@ describe('deployment-spec-generator', () => {
       const sequencerValues = yaml.load(files['l2-sequencer-production.yaml']) as any;
       expect(sequencerValues.command).to.deep.equal(['bash', '-c', 'exec dogeos-reth-entrypoint']);
       expect(sequencerValues.configMaps.env.data.L2RETH_ROLE).to.equal('sequencer');
+      expect(sequencerValues.configMaps.env.data.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK).to.equal('8200000');
       expect(sequencerValues.configMaps.env.data.L2RETH_VALID_SIGNER).to.equal('__SEQUENCER_SIGNER_ADDRESS__');
       expect(sequencerValues.envFrom).to.deep.equal([{ configMapRef: { name: 'l2-sequencer-__INSTANCE_INDEX__-env' } }]);
       expect(sequencerValues.persistence.data.mountPath).to.equal('/l2reth/reth-data');
@@ -1229,6 +1239,22 @@ describe('deployment-spec-generator', () => {
       const rpcValues = yaml.load(files['l2-rpc-production.yaml']) as any;
       expect(rpcValues.configMaps.env.data.L2RETH_ROLE).to.equal('rpc');
       expect(rpcValues.volumeClaimTemplates[0].mountPath).to.equal('/l2reth/reth-data');
+    });
+
+    it('preserves explicit scroll-reth image overrides', () => {
+      const spec = createMinimalSpec();
+      spec.executionClient = { backend: 'scroll-reth' };
+      spec.images = {
+        services: {
+          l2Rpc: { repository: 'example/scroll-reth', tag: 'custom-reth' },
+        },
+      };
+
+      const files = generateValuesFiles(spec);
+      const rpcValues = yaml.load(files['l2-rpc-production.yaml']) as any;
+
+      expect(rpcValues.image.repository).to.equal('example/scroll-reth');
+      expect(rpcValues.image.tag).to.equal('custom-reth');
     });
 
     it('generates l1-interface genesis and indexer heights independently', () => {

--- a/test/utils/deployment-spec-generator.test.ts
+++ b/test/utils/deployment-spec-generator.test.ts
@@ -1227,17 +1227,24 @@ describe('deployment-spec-generator', () => {
       expect(sequencerValues.configMaps.env.data.L2RETH_ROLE).to.equal('sequencer');
       expect(sequencerValues.configMaps.env.data.L2RETH_L1_CONTRACT_DEPLOYMENT_BLOCK).to.equal('8200000');
       expect(sequencerValues.configMaps.env.data.L2RETH_VALID_SIGNER).to.equal('__SEQUENCER_SIGNER_ADDRESS__');
+      expect(sequencerValues.configMaps.env.data.L2RETH_EXTRA_PARAMS).to.equal('--metrics 0.0.0.0:6060');
       expect(sequencerValues.envFrom).to.deep.equal([{ configMapRef: { name: 'l2-sequencer-__INSTANCE_INDEX__-env' } }]);
       expect(sequencerValues.persistence.data.mountPath).to.equal('/l2reth/reth-data');
       expect(sequencerValues.persistence.genesis.mountPath).to.equal('/l2reth/genesis/genesis.json');
+      expect(sequencerValues.probes.readiness.enabled).to.equal(false);
       expect(sequencerValues).not.to.have.property('externalSecrets');
 
       const bootnodeValues = yaml.load(files['l2-bootnode-production.yaml']) as any;
       expect(bootnodeValues.configMaps.env.data.L2RETH_ROLE).to.equal('bootnode');
+      expect(bootnodeValues.configMaps.env.data.L2RETH_EXTRA_PARAMS).to.equal('');
       expect(bootnodeValues.persistence.data.mountPath).to.equal('/l2reth/reth-data');
+      expect(bootnodeValues.service.main.enabled).to.equal(false);
+      expect(bootnodeValues.serviceMonitor.main.enabled).to.equal(false);
 
       const rpcValues = yaml.load(files['l2-rpc-production.yaml']) as any;
       expect(rpcValues.configMaps.env.data.L2RETH_ROLE).to.equal('rpc');
+      expect(rpcValues.configMaps.env.data.L2RETH_EXTRA_PARAMS).to.equal('--metrics 0.0.0.0:6060');
+      expect(rpcValues.probes.startup.enabled).to.equal(false);
       expect(rpcValues.volumeClaimTemplates[0].mountPath).to.equal('/l2reth/reth-data');
     });
 


### PR DESCRIPTION
## Summary
- add `executionClient.backend` to DeploymentSpec with `l2geth` default and `scroll-reth` opt-in
- branch L2 sequencer/RPC/bootnode values generation for `scroll-reth`
- emit `L2RETH_*` env, reth image defaults, reth datadir/genesis paths, and `dogeos-reth-entrypoint`
- split RPC package env generation so `l2reth.env` no longer depends on `L2GETH_*`
- validate required Scroll/DogeOS reth genesis fields before writing `l2reth-genesis.json`

Linear: [DOG-384](https://linear.app/dogeos69/issue/DOG-384/add-opt-in-scroll-reth-dogeos-revm-backend)

## Testing
- `yarn build`
- `yarn test test/utils/deployment-spec-generator.test.ts test/commands/setup/gen-rpc-package.test.ts`
- `./node_modules/.bin/mocha --forbid-only test/commands/setup/gen-rpc-package.test.ts`

## Notes
- Full `yarn test ...` completed with existing lint warnings only.
- `scroll-reth` output is generated only when explicitly selected.
